### PR TITLE
Add object-shorthand rule, for properties only

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,5 +109,6 @@ module.exports = {
         ignoreDeclarationSort: true,
       },
     ],
+    "object-shorthand": ["error", "properties"]
   },
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-discourse",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "Shareable eslint config for Discourse and plugins",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
I thought it best to just stick to properties for now, we can further refine the rule later if needed. Below, `bumpedAtDate` will error but `cool` will not.


```javascript
const someobj = {
  bumpedAtDate: bumpedAtDate,
  cool: function () {
    return "dude";
  },
};
```