### PR TITLE
FIX: Move template-no-let-reference rule to gjs section

### DIFF
--- a/lint-configs/eslintrc.cjs
+++ b/lint-configs/eslintrc.cjs
@@ -163,7 +163,6 @@ module.exports = {
     "ember/route-path-style": "off",
     "ember/routes-segments-snake-case": "off",
     "ember/no-replace-test-comments": "error",
-    "ember/template-no-let-reference": "off", // we have valid cases of using let variables in templates
 
     "qunit/no-assert-equal-boolean": "off",
     "qunit/no-assert-equal": "off",
@@ -255,6 +254,9 @@ module.exports = {
       files: ["**/*.gjs"],
       parser: "ember-eslint-parser",
       extends: ["plugin:ember/recommended-gjs"],
+      rules: {
+        "ember/template-no-let-reference": "off", // we have valid cases of using let variables in templates
+      },
     },
   ],
 };


### PR DESCRIPTION
I added it to the regular js section yesterday by mistake. It's enabled only for gjs, so the entry was a no-op.