### PR TITLE
Introduce no-simple-queryselector rule

### DIFF
--- a/lint-configs/eslint-rules/no-simple-queryselector.mjs
+++ b/lint-configs/eslint-rules/no-simple-queryselector.mjs
@@ -1,0 +1,46 @@
+// no-queryselector-body-html.mjs
+export default {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        'disallow document.querySelector("body") and document.querySelector("html")',
+      category: "Best Practices",
+      recommended: false,
+    },
+    fixable: "code",
+    schema: [], // no options
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        const { callee, arguments: args } = node;
+
+        if (
+          callee.type === "MemberExpression" &&
+          callee.object.name === "document" &&
+          callee.property.name === "querySelector" &&
+          args.length === 1 &&
+          args[0].type === "Literal"
+        ) {
+          if (args[0].value === "body") {
+            context.report({
+              node,
+              message:
+                'Avoid using document.querySelector("body"). Use document.body instead.',
+              fix: (fixer) => fixer.replaceText(node, "document.body"),
+            });
+          } else if (args[0].value === "html") {
+            context.report({
+              node,
+              message:
+                'Avoid using document.querySelector("html"). Use document.documentElement instead.',
+              fix: (fixer) =>
+                fixer.replaceText(node, "document.documentElement"),
+            });
+          }
+        }
+      },
+    };
+  },
+};

--- a/lint-configs/eslint.mjs
+++ b/lint-configs/eslint.mjs
@@ -11,6 +11,7 @@ import SortClassMembers from "eslint-plugin-sort-class-members";
 import globals from "globals";
 import i18nImport from "./eslint-rules/i18n-import-location.mjs";
 import i18nT from "./eslint-rules/i18n-t.mjs";
+import noSimpleQueryselector from "./eslint-rules/no-simple-queryselector.mjs";
 import serviceInjectImport from "./eslint-rules/service-inject-import.mjs";
 
 // Copied from "ember-template-imports/lib/utils"
@@ -93,6 +94,7 @@ export default [
           "i18n-import-location": i18nImport,
           "i18n-t": i18nT,
           "service-inject-import": serviceInjectImport,
+          "no-simple-queryselector": noSimpleQueryselector,
         },
       },
     },
@@ -264,6 +266,7 @@ export default [
       // "discourse/i18n-import-location": ["error"],
       // "discourse/i18n-t": ["error"],
       "discourse/service-inject-import": ["error"],
+      "discourse/no-simple-queryselector": ["error"],
     },
   },
   {

--- a/test/eslint-rules/no-simple-queryselector.mjs
+++ b/test/eslint-rules/no-simple-queryselector.mjs
@@ -1,0 +1,36 @@
+// no-queryselector-body-html.test.mjs
+import { RuleTester } from "eslint";
+import rule from "./no-queryselector-body-html.mjs";
+
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2020 } });
+
+ruleTester.run("no-queryselector-body-html", rule, {
+  valid: [
+    'document.querySelector(".my-class")',
+    "document.body",
+    "document.documentElement",
+    'someOtherObject.querySelector("body")',
+  ],
+  invalid: [
+    {
+      code: 'document.querySelector("body")',
+      errors: [
+        {
+          message:
+            'Avoid using document.querySelector("body"). Use document.body instead.',
+        },
+      ],
+      output: "document.body",
+    },
+    {
+      code: 'document.querySelector("html")',
+      errors: [
+        {
+          message:
+            'Avoid using document.querySelector("html"). Use document.documentElement instead.',
+        },
+      ],
+      output: "document.documentElement",
+    },
+  ],
+});


### PR DESCRIPTION
Blocks `document.querySelector("html")` and `document.querySelector("body")`