### PR TITLE
Introduce `discourse/no-implicit-this` with autofix

### DIFF
--- a/lint-configs/template-lint-rules/index.mjs
+++ b/lint-configs/template-lint-rules/index.mjs
@@ -1,4 +1,5 @@
 import NoAtClass from "./no-at-class.mjs";
+import NoImplicitThis from "./no-implicit-this.mjs";
 
 export default {
   // Name of plugin
@@ -7,5 +8,6 @@ export default {
   // Define rules for this plugin. Each path should map to a plugin rule
   rules: {
     "discourse/no-at-class": NoAtClass,
+    "discourse/no-implicit-this": NoImplicitThis,
   },
 };

--- a/lint-configs/template-lint-rules/no-implicit-this.mjs
+++ b/lint-configs/template-lint-rules/no-implicit-this.mjs
@@ -1,0 +1,174 @@
+// Adapted from https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/no-implicit-this.md
+// With the addition of autofix
+
+import { Rule } from "ember-template-lint";
+
+function createErrorMessage(ruleName, lines, config) {
+  return [
+    `The ${ruleName} rule accepts one of the following values.`,
+    lines,
+    `You specified \`${JSON.stringify(config)}\``,
+  ].join("\n");
+}
+
+function message(original) {
+  return (
+    `Ambiguous path '${original}' is not allowed. ` +
+    `Use '@${original}' if it is a named argument ` +
+    `or 'this.${original}' if it is a property on 'this'. ` +
+    "If it is a helper or component that has no arguments, " +
+    "you must either convert it to an angle bracket invocation " +
+    "or manually add it to the 'no-implicit-this' rule configuration, e.g. " +
+    `'no-implicit-this': { allow: ['${original}'] }.`
+  );
+}
+
+function isString(value) {
+  return typeof value === "string";
+}
+
+function isRegExp(value) {
+  return value instanceof RegExp;
+}
+
+function allowedFormat(value) {
+  return isString(value) || isRegExp(value);
+}
+
+// Allow Ember's builtin argless syntaxes
+export const ARGLESS_BUILTIN_HELPERS = [
+  "array",
+  "concat",
+  "debugger",
+  "has-block",
+  "hasBlock",
+  "has-block-params",
+  "hasBlockParams",
+  "hash",
+  "input",
+  "log",
+  "outlet",
+  "query-params",
+  "textarea",
+  "yield",
+  "unique-id",
+];
+
+// arg'less Components / Helpers in default ember-cli blueprint
+const ARGLESS_DEFAULT_BLUEPRINT = [
+  "welcome-page",
+  /* from app/index.html and tests/index.html */
+  "rootURL",
+];
+
+export default class NoImplicitThis extends Rule {
+  parseConfig(config) {
+    if (config === false || config === undefined || !this.isStrictMode) {
+      return false;
+    }
+
+    switch (typeof config) {
+      case "undefined": {
+        return false;
+      }
+
+      case "boolean": {
+        if (config) {
+          return {
+            allow: [...ARGLESS_BUILTIN_HELPERS, ...ARGLESS_DEFAULT_BLUEPRINT],
+          };
+        } else {
+          return false;
+        }
+      }
+
+      case "object": {
+        if (Array.isArray(config.allow) && config.allow.every(allowedFormat)) {
+          return {
+            allow: [
+              ...ARGLESS_BUILTIN_HELPERS,
+              ...ARGLESS_DEFAULT_BLUEPRINT,
+              ...config.allow,
+            ],
+          };
+        }
+        break;
+      }
+    }
+
+    let errorMessage = createErrorMessage(
+      this.ruleName,
+      [
+        "  * boolean - `true` to enable / `false` to disable",
+        "  * object -- An object with the following keys:",
+        "    * `allow` -- An array of component / helper names for that may be called without arguments",
+      ],
+      config
+    );
+
+    throw new Error(errorMessage);
+  }
+
+  // The way this visitor works is a bit sketchy. We need to lint the PathExpressions
+  // in the callee position differently those in an argument position.
+  //
+  // Unfortunately, the current visitor API doesn't give us a good way to differentiate
+  // these two cases. Instead, we rely on the fact that the _first_ PathExpression that
+  // we enter after entering a MustacheStatement/BlockStatement/... will be the callee
+  // and we track this using a flag called `nextPathIsCallee`.
+  visitor() {
+    let nextPathIsCallee = false;
+
+    return {
+      PathExpression(path) {
+        if (nextPathIsCallee) {
+          // All paths are valid callees so there's nothing to check.
+        } else {
+          let valid =
+            path.data ||
+            path.this ||
+            this.isLocal(path) ||
+            this.config.allow.some((item) => {
+              return isRegExp(item)
+                ? item.test(path.original)
+                : item === path.original;
+            });
+
+          if (!valid) {
+            if (this.mode === "fix") {
+              path.original = `this.${path.original}`;
+            } else {
+              this.log({
+                message: message(path.original),
+                node: path,
+                isFixable: true,
+              });
+            }
+          }
+        }
+
+        nextPathIsCallee = false;
+      },
+
+      SubExpression() {
+        nextPathIsCallee = true;
+      },
+
+      ElementModifierStatement() {
+        nextPathIsCallee = true;
+      },
+
+      MustacheStatement(node) {
+        let isCall = node.params.length > 0 || node.hash.pairs.length > 0;
+
+        nextPathIsCallee = isCall;
+      },
+
+      BlockStatement: {
+        enter() {
+          nextPathIsCallee = true;
+        },
+      },
+    };
+  }
+}

--- a/lint-configs/template-lint.config.cjs
+++ b/lint-configs/template-lint.config.cjs
@@ -46,5 +46,20 @@ module.exports = {
 
     // Discourse custom
     "discourse/no-at-class": true,
+    "discourse/no-implicit-this": {
+      allow: [
+        "hide-application-footer",
+        "hide-application-sidebar",
+        "loading-spinner",
+      ],
+    },
   },
+  overrides: [
+    {
+      files: ["**/*.gjs", "**/*.gts"],
+      rules: {
+        "discourse/no-implicit-this": false,
+      },
+    },
+  ],
 };

--- a/test/template-lint-rules/no-implicit-this.test.mjs
+++ b/test/template-lint-rules/no-implicit-this.test.mjs
@@ -1,0 +1,30 @@
+import { generateRuleTests } from "ember-template-lint";
+import plugin from "../../lint-configs/template-lint-rules/index.mjs";
+
+generateRuleTests({
+  name: "discourse/no-implicit-this",
+
+  groupMethodBefore: beforeEach,
+  groupingMethod: describe,
+  testMethod: it,
+  plugins: [plugin],
+
+  config: true,
+
+  good: ["{{this.foo}}"],
+
+  bad: [
+    {
+      template: "{{foo}}",
+      fixedTemplate: "{{this.foo}}",
+      result: {
+        column: 2,
+        line: 1,
+        source: "foo",
+        message:
+          "Ambiguous path 'foo' is not allowed. Use '@foo' if it is a named argument or 'this.foo' if it is a property on 'this'. If it is a helper or component that has no arguments, you must either convert it to an angle bracket invocation or manually add it to the 'no-implicit-this' rule configuration, e.g. 'no-implicit-this': { allow: ['foo'] }.",
+        isFixable: true,
+      },
+    },
+  ],
+});


### PR DESCRIPTION
This is copy/pasted from upstream's `no-implicit-this` rule, with the addition of autofix functionality. Upstream likely decided against autofix because it's possible for this rule to raise false-positives, which then require helpers to be added to the 'allow' list. However, in our case, the allow list is preconfigured with core helpers, and it's exceptionally rare for plugins/themes to introduce their own argument-less helpers.