### PR TITLE
Use import for plugin-proposal-decorators

### DIFF
--- a/lint-configs/eslint.mjs
+++ b/lint-configs/eslint.mjs
@@ -1,4 +1,5 @@
 import BabelParser from "@babel/eslint-parser";
+import PluginProposalDecorators from "@babel/plugin-proposal-decorators";
 import js from "@eslint/js";
 import stylisticJs from "@stylistic/eslint-plugin-js";
 import EmberESLintParser from "ember-eslint-parser";
@@ -31,7 +32,7 @@ export default [
       parserOptions: {
         requireConfigFile: false,
         babelOptions: {
-          plugins: [["@babel/plugin-proposal-decorators", { legacy: true }]],
+          plugins: [[PluginProposalDecorators, { legacy: true }]],
         },
       },
 


### PR DESCRIPTION
We're getting reports of `Cannot find module '@babel/plugin-proposal-decorators'`. This commit imports the plugin directly and passes it to the eslint config. That way, babel itself doesn't have to do any package resolution.