### PR TITLE
Fully enable property-no-vendor-prefix stylelint rule

### DIFF
--- a/lint-configs/stylelint.mjs
+++ b/lint-configs/stylelint.mjs
@@ -28,15 +28,5 @@ export default {
     "scss/comment-no-empty": null,
     "scss/at-mixin-pattern": null,
     "media-feature-range-notation": "prefix",
-    "property-no-vendor-prefix": [
-      true,
-      {
-        ignoreProperties: [
-          "backdrop-filter",
-          "text-size-adjust",
-          "user-select",
-        ],
-      },
-    ],
   },
 };


### PR DESCRIPTION
Discourse now has autoprefixer, so no need to specify these manually