### PR TITLE
FEATURE: Extend lines-between-class-members

### DIFF
--- a/lint-configs/eslint-rules/lines-between-class-members.mjs
+++ b/lint-configs/eslint-rules/lines-between-class-members.mjs
@@ -1,0 +1,293 @@
+function isTokenOnSameLine(left, right) {
+  return left?.loc?.end.line === right?.loc?.start.line;
+}
+
+function isSemicolonToken(token) {
+  return token.value === ";" && token.type === "Punctuator";
+}
+
+export default {
+  meta: {
+    type: "layout",
+    docs: {
+      description: "Require an empty line between class members",
+    },
+    fixable: "whitespace",
+    schema: [], // no options
+    messages: {
+      never: "Unexpected blank line between class members.",
+      always: "Expected blank line between class members.",
+    },
+  },
+
+  create(context) {
+    const configureList = [
+      { blankLine: "always", prev: "service", next: "*" },
+      { blankLine: "always", prev: "tracked", next: "*" },
+      { blankLine: "always", prev: "*", next: "method" },
+      { blankLine: "always", prev: "method", next: "*" },
+      { blankLine: "always", prev: "*", next: "template" },
+    ];
+    const sourceCode = context.sourceCode;
+
+    /**
+     * Gets a pair of tokens that should be used to check lines between two class member nodes.
+     *
+     * In most cases, this returns the very last token of the current node and
+     * the very first token of the next node.
+     * For example:
+     *
+     *     class C {
+     *         x = 1;   // curLast: `;` nextFirst: `in`
+     *         in = 2
+     *     }
+     *
+     * There is only one exception. If the given node ends with a semicolon, and it looks like
+     * a semicolon-less style's semicolon - one that is not on the same line as the preceding
+     * token, but is on the line where the next class member starts - this returns the preceding
+     * token and the semicolon as boundary tokens.
+     * For example:
+     *
+     *     class C {
+     *         x = 1    // curLast: `1` nextFirst: `;`
+     *         ;in = 2
+     *     }
+     * When determining the desired layout of the code, we should treat this semicolon as
+     * a part of the next class member node instead of the one it technically belongs to.
+     * @param curNode Current class member node.
+     * @param nextNode Next class member node.
+     * @returns The actual last token of `node`.
+     * @private
+     */
+    function getBoundaryTokens(curNode, nextNode) {
+      const lastToken = sourceCode.getLastToken(curNode);
+      const prevToken = sourceCode.getTokenBefore(lastToken);
+      const nextToken = sourceCode.getFirstToken(nextNode); // skip possible lone `;` between nodes
+
+      const isSemicolonLessStyle =
+        isSemicolonToken(lastToken) &&
+        !isTokenOnSameLine(prevToken, lastToken) &&
+        isTokenOnSameLine(lastToken, nextToken);
+
+      return isSemicolonLessStyle
+        ? { curLast: prevToken, nextFirst: lastToken }
+        : { curLast: lastToken, nextFirst: nextToken };
+    }
+
+    /**
+     * Return the last token among the consecutive tokens that have no exceed max line difference in between, before the first token in the next member.
+     * @param prevLastToken The last token in the previous member node.
+     * @param nextFirstToken The first token in the next member node.
+     * @param maxLine The maximum number of allowed line difference between consecutive tokens.
+     * @returns  The last token among the consecutive tokens.
+     */
+    function findLastConsecutiveTokenAfter(
+      prevLastToken,
+      nextFirstToken,
+      maxLine
+    ) {
+      const after = sourceCode.getTokenAfter(prevLastToken, {
+        includeComments: true,
+      });
+
+      if (
+        after !== nextFirstToken &&
+        after.loc.start.line - prevLastToken.loc.end.line <= maxLine
+      ) {
+        return findLastConsecutiveTokenAfter(after, nextFirstToken, maxLine);
+      }
+
+      return prevLastToken;
+    }
+
+    /**
+     * Return the first token among the consecutive tokens that have no exceed max line difference in between, after the last token in the previous member.
+     * @param nextFirstToken The first token in the next member node.
+     * @param prevLastToken The last token in the previous member node.
+     * @param maxLine The maximum number of allowed line difference between consecutive tokens.
+     * @returns The first token among the consecutive tokens.
+     */
+    function findFirstConsecutiveTokenBefore(
+      nextFirstToken,
+      prevLastToken,
+      maxLine
+    ) {
+      const before = sourceCode.getTokenBefore(nextFirstToken, {
+        includeComments: true,
+      });
+
+      if (
+        before !== prevLastToken &&
+        nextFirstToken.loc.start.line - before.loc.end.line <= maxLine
+      ) {
+        return findFirstConsecutiveTokenBefore(before, prevLastToken, maxLine);
+      }
+
+      return nextFirstToken;
+    }
+
+    /**
+     * Checks if there is a token or comment between two tokens.
+     * @param before The token before.
+     * @param after The token after.
+     * @returns True if there is a token or comment between two tokens.
+     */
+    function hasTokenOrCommentBetween(before, after) {
+      return (
+        sourceCode.getTokensBetween(before, after, { includeComments: true })
+          .length !== 0
+      );
+    }
+
+    /**
+     * Returns the type of the node.
+     * @param node The class member node to check.
+     * @returns The type string (see `configureList`)
+     * @private
+     */
+    function nodeType(node) {
+      if (
+        node.type === "PropertyDefinition" &&
+        node.decorators?.[0]?.expression?.name === "tracked"
+      ) {
+        return "tracked";
+      } else if (
+        node.type === "PropertyDefinition" &&
+        [("service", "optionalService", "controller")].includes(
+          node.decorators?.[0]?.expression?.name
+        )
+      ) {
+        return "service";
+      } else if (node.type === "PropertyDefinition") {
+        return "field";
+      } else if (node.type === "MethodDefinition") {
+        return "method";
+      } else if (node.type === "GlimmerTemplate") {
+        return "template";
+      } else {
+        return "other";
+      }
+    }
+
+    /**
+     * Checks whether the given node matches the given type.
+     * @param node The class member node to check.
+     * @param type The class member type to check.
+     * @returns `true` if the class member node matched the type.
+     * @private
+     */
+    function match(node, type) {
+      if (type === "*") {
+        return true;
+      } else if (type === "tracked") {
+        return (
+          node.type === "PropertyDefinition" &&
+          node.decorators?.[0]?.expression?.name === "tracked"
+        );
+      } else if (type === "service") {
+        return (
+          node.type === "PropertyDefinition" &&
+          ["service", "optionalService", "controller"].includes(
+            node.decorators?.[0]?.expression?.name
+          )
+        );
+      } else if (type === "field") {
+        return node.type === "PropertyDefinition";
+      } else if (type === "method") {
+        return node.type === "MethodDefinition";
+      } else if (type === "template") {
+        return node.type === "GlimmerTemplate";
+      }
+    }
+
+    /**
+     * Finds the last matched configuration from the configureList.
+     * @param prevNode The previous node to match.
+     * @param nextNode The current node to match.
+     * @returns Padding type or `null` if no matches were found.
+     * @private
+     */
+    function getPaddingType(prevNode, nextNode) {
+      for (let i = configureList.length - 1; i >= 0; --i) {
+        const configure = configureList[i];
+        const matched =
+          match(prevNode, configure.prev) && match(nextNode, configure.next);
+
+        if (matched) {
+          return configure.blankLine;
+        }
+      }
+      return null;
+    }
+
+    return {
+      ClassBody(node) {
+        const body = node.body;
+
+        for (let i = 0; i < body.length - 1; i++) {
+          const curFirst = sourceCode.getFirstToken(body[i]);
+          const { curLast, nextFirst } = getBoundaryTokens(
+            body[i],
+            body[i + 1]
+          );
+          const singleLine = isTokenOnSameLine(curFirst, curLast);
+          const skip =
+            singleLine && nodeType(body[i]) === nodeType(body[i + 1]);
+          const beforePadding = findLastConsecutiveTokenAfter(
+            curLast,
+            nextFirst,
+            1
+          );
+          const afterPadding = findFirstConsecutiveTokenBefore(
+            nextFirst,
+            curLast,
+            1
+          );
+          const isPadded =
+            afterPadding.loc.start.line - beforePadding.loc.end.line > 1;
+          const hasTokenInPadding = hasTokenOrCommentBetween(
+            beforePadding,
+            afterPadding
+          );
+          const curLineLastToken = findLastConsecutiveTokenAfter(
+            curLast,
+            nextFirst,
+            0
+          );
+          const paddingType = getPaddingType(body[i], body[i + 1]);
+
+          if (paddingType === "never" && isPadded) {
+            context.report({
+              node: body[i + 1],
+              messageId: "never",
+
+              fix(fixer) {
+                if (hasTokenInPadding) {
+                  return null;
+                }
+
+                return fixer.replaceTextRange(
+                  [beforePadding.range[1], afterPadding.range[0]],
+                  "\n"
+                );
+              },
+            });
+          } else if (paddingType === "always" && !skip && !isPadded) {
+            context.report({
+              node: body[i + 1],
+              messageId: "always",
+
+              fix(fixer) {
+                if (hasTokenInPadding) {
+                  return null;
+                }
+
+                return fixer.insertTextAfter(curLineLastToken, "\n");
+              },
+            });
+          }
+        }
+      },
+    };
+  },
+};

--- a/lint-configs/eslint-rules/lines-between-class-members.mjs
+++ b/lint-configs/eslint-rules/lines-between-class-members.mjs
@@ -174,21 +174,9 @@ export default {
     function match(node, type) {
       if (type === "*") {
         return true;
-      } else if (type === "service") {
-        return (
-          node.type === "PropertyDefinition" &&
-          ["service", "optionalService", "controller"].includes(
-            node.decorators?.[0]?.expression?.name ||
-              node.decorators?.[0]?.expression?.callee?.name
-          )
-        );
-      } else if (type === "field") {
-        return node.type === "PropertyDefinition";
-      } else if (type === "method") {
-        return node.type === "MethodDefinition";
-      } else if (type === "template") {
-        return node.type === "GlimmerTemplate";
       }
+
+      return nodeType(node) === type;
     }
 
     /**

--- a/lint-configs/eslint-rules/lines-between-class-members.mjs
+++ b/lint-configs/eslint-rules/lines-between-class-members.mjs
@@ -148,7 +148,8 @@ export default {
       if (
         node.type === "PropertyDefinition" &&
         ["service", "optionalService", "controller"].includes(
-          node.decorators?.[0]?.expression?.name
+          node.decorators?.[0]?.expression?.name ||
+            node.decorators?.[0]?.expression?.callee?.name
         )
       ) {
         return "service";
@@ -177,7 +178,8 @@ export default {
         return (
           node.type === "PropertyDefinition" &&
           ["service", "optionalService", "controller"].includes(
-            node.decorators?.[0]?.expression?.name
+            node.decorators?.[0]?.expression?.name ||
+              node.decorators?.[0]?.expression?.callee?.name
           )
         );
       } else if (type === "field") {

--- a/lint-configs/eslint-rules/lines-between-class-members.mjs
+++ b/lint-configs/eslint-rules/lines-between-class-members.mjs
@@ -23,7 +23,6 @@ export default {
   create(context) {
     const configureList = [
       { blankLine: "always", prev: "service", next: "*" },
-      { blankLine: "always", prev: "tracked", next: "*" },
       { blankLine: "always", prev: "*", next: "method" },
       { blankLine: "always", prev: "method", next: "*" },
       { blankLine: "always", prev: "*", next: "template" },
@@ -148,11 +147,6 @@ export default {
     function nodeType(node) {
       if (
         node.type === "PropertyDefinition" &&
-        node.decorators?.[0]?.expression?.name === "tracked"
-      ) {
-        return "tracked";
-      } else if (
-        node.type === "PropertyDefinition" &&
         ["service", "optionalService", "controller"].includes(
           node.decorators?.[0]?.expression?.name
         )
@@ -179,11 +173,6 @@ export default {
     function match(node, type) {
       if (type === "*") {
         return true;
-      } else if (type === "tracked") {
-        return (
-          node.type === "PropertyDefinition" &&
-          node.decorators?.[0]?.expression?.name === "tracked"
-        );
       } else if (type === "service") {
         return (
           node.type === "PropertyDefinition" &&

--- a/lint-configs/eslint-rules/lines-between-class-members.mjs
+++ b/lint-configs/eslint-rules/lines-between-class-members.mjs
@@ -153,7 +153,7 @@ export default {
         return "tracked";
       } else if (
         node.type === "PropertyDefinition" &&
-        [("service", "optionalService", "controller")].includes(
+        ["service", "optionalService", "controller"].includes(
           node.decorators?.[0]?.expression?.name
         )
       ) {

--- a/lint-configs/eslint.mjs
+++ b/lint-configs/eslint.mjs
@@ -2,7 +2,6 @@ import { createConfigItem } from "@babel/core";
 import BabelParser from "@babel/eslint-parser";
 import PluginProposalDecorators from "@babel/plugin-proposal-decorators";
 import js from "@eslint/js";
-import stylisticJs from "@stylistic/eslint-plugin-js";
 import EmberESLintParser from "ember-eslint-parser";
 import DecoratorPosition from "eslint-plugin-decorator-position";
 import EmberPlugin from "eslint-plugin-ember";
@@ -17,6 +16,7 @@ import deprecatedLookups from "./eslint-rules/deprecated-lookups.mjs";
 import discourseCommonImports from "./eslint-rules/discourse-common-imports.mjs";
 import i18nImport from "./eslint-rules/i18n-import-location.mjs";
 import i18nT from "./eslint-rules/i18n-t.mjs";
+import linesBetweenClassMembers from "./eslint-rules/lines-between-class-members.mjs";
 import noSimpleQueryselector from "./eslint-rules/no-simple-queryselector.mjs";
 import serviceInjectImport from "./eslint-rules/service-inject-import.mjs";
 
@@ -96,7 +96,6 @@ export default [
       },
     },
     plugins: {
-      "@stylistic/js": stylisticJs,
       ember: EmberPlugin,
       "sort-class-members": SortClassMembers,
       "decorator-position": DecoratorPosition,
@@ -111,6 +110,7 @@ export default [
           "no-simple-queryselector": noSimpleQueryselector,
           "deprecated-lookups": deprecatedLookups,
           "discourse-common-imports": discourseCommonImports,
+          "lines-between-class-members": linesBetweenClassMembers,
         },
       },
     },
@@ -161,16 +161,6 @@ export default [
       "import/no-duplicates": "error",
       "object-shorthand": ["error", "properties"],
       "no-dupe-class-members": "error",
-      "@stylistic/js/lines-between-class-members": [
-        "error",
-        {
-          enforce: [
-            { blankLine: "always", prev: "*", next: "method" },
-            { blankLine: "always", prev: "method", next: "*" },
-          ],
-        },
-        { exceptAfterSingleLine: true },
-      ],
       "ember/no-classic-components": "off",
       "ember/no-component-lifecycle-hooks": "off",
       "ember/require-tagless-components": "off",
@@ -292,6 +282,7 @@ export default [
       "discourse/no-simple-queryselector": ["error"],
       "discourse/deprecated-lookups": ["error"],
       "discourse/discourse-common-imports": ["error"],
+      "discourse/lines-between-class-members": ["error"],
     },
   },
   {

--- a/lint-configs/package.json
+++ b/lint-configs/package.json
@@ -33,7 +33,6 @@
     "@babel/core": "^7.26.9",
     "@babel/eslint-parser": "^7.26.8",
     "@babel/plugin-proposal-decorators": "^7.25.9",
-    "@stylistic/eslint-plugin-js": "^4.2.0",
     "ember-template-lint": "^7.0.0",
     "eslint": "^9.21.0",
     "eslint-plugin-decorator-position": "^6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,9 +19,6 @@ importers:
       '@babel/plugin-proposal-decorators':
         specifier: ^7.25.9
         version: 7.25.9(@babel/core@7.26.9)
-      '@stylistic/eslint-plugin-js':
-        specifier: ^4.2.0
-        version: 4.2.0(eslint@9.21.0)
       ember-template-lint:
         specifier: ^7.0.0
         version: 7.0.0(@babel/core@7.26.9)
@@ -448,12 +445,6 @@ packages:
   '@sindresorhus/merge-streams@2.3.0':
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
     engines: {node: '>=18'}
-
-  '@stylistic/eslint-plugin-js@4.2.0':
-    resolution: {integrity: sha512-MiJr6wvyzMYl/wElmj8Jns8zH7Q1w8XoVtm+WM6yDaTrfxryMyb8n0CMxt82fo42RoLIfxAEtM6tmQVxqhk0/A==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: '>=9.0.0'
 
   '@types/eslint@8.56.12':
     resolution: {integrity: sha512-03ruubjWyOHlmljCVoxSuNDdmfZDzsrrz0P2LeJsOXr+ZwFQ+0yQIwNCwt/GYhV7Z31fgtXJTAEs+FYlEL851g==}
@@ -2554,12 +2545,6 @@ snapshots:
   '@simple-dom/interface@1.4.0': {}
 
   '@sindresorhus/merge-streams@2.3.0': {}
-
-  '@stylistic/eslint-plugin-js@4.2.0(eslint@9.21.0)':
-    dependencies:
-      eslint: 9.21.0
-      eslint-visitor-keys: 4.2.0
-      espree: 10.3.0
 
   '@types/eslint@8.56.12':
     dependencies:

--- a/test/eslint-rules/lines-between-class-members.test.mjs
+++ b/test/eslint-rules/lines-between-class-members.test.mjs
@@ -42,6 +42,18 @@ ruleTester.run("lines-between-class-members", rule, {
         }
       `,
     },
+    {
+      code: `
+        class Foo {
+          @service bar;
+          @service baz;
+          @optionalService hey;
+          @controller hello;
+
+          <template></template>
+        }
+      `,
+    },
   ],
   invalid: [
     {

--- a/test/eslint-rules/lines-between-class-members.test.mjs
+++ b/test/eslint-rules/lines-between-class-members.test.mjs
@@ -1,0 +1,148 @@
+import EmberESLintParser from "ember-eslint-parser";
+import { RuleTester } from "eslint";
+import rule from "../../lint-configs/eslint-rules/lines-between-class-members.mjs";
+
+const ruleTester = new RuleTester({
+  languageOptions: { parser: EmberESLintParser, ecmaVersion: 2018 },
+});
+
+ruleTester.run("lines-between-class-members", rule, {
+  valid: [
+    {
+      code: `
+        class Foo {
+          get baz() {
+            return 0;
+          }
+
+          @action quux() {
+            return 1;
+          }
+
+          <template></template>
+        }
+      `,
+    },
+    {
+      code: `
+        class Foo {
+          @tracked bar;
+          @tracked baz;
+
+          <template></template>
+        }
+      `,
+    },
+    {
+      code: `
+        class Foo {
+          @tracked bar;
+
+          <template></template>
+        }
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        class Foo {
+          @tracked bar;
+          <template></template>
+        }
+      `,
+      errors: [{ message: "Expected blank line between class members." }],
+      output: `
+        class Foo {
+          @tracked bar;
+
+          <template></template>
+        }
+      `,
+    },
+    {
+      code: `
+        class Foo {
+          get baz() {
+            return 0;
+          }
+          <template></template>
+        }
+      `,
+      errors: [{ message: "Expected blank line between class members." }],
+      output: `
+        class Foo {
+          get baz() {
+            return 0;
+          }
+
+          <template></template>
+        }
+      `,
+    },
+    {
+      code: `
+        class Foo {
+          @service modal;
+          @service store;
+          @tracked counter;
+          @tracked text;
+        }
+      `,
+      errors: [{ message: "Expected blank line between class members." }],
+      output: `
+        class Foo {
+          @service modal;
+          @service store;
+
+          @tracked counter;
+          @tracked text;
+        }
+      `,
+    },
+    {
+      code: `
+        class Foo {
+          @service modal;
+          @tracked counter;
+          @tracked text;
+          other = 0;
+          get bar() {
+            return 1;
+          }
+          @action alert() {
+            return 2;
+          }
+          <template></template>
+        }
+      `,
+      errors: [
+        { message: "Expected blank line between class members." },
+        { message: "Expected blank line between class members." },
+        { message: "Expected blank line between class members." },
+        { message: "Expected blank line between class members." },
+        { message: "Expected blank line between class members." },
+      ],
+      output: `
+        class Foo {
+          @service modal;
+
+          @tracked counter;
+          @tracked text;
+
+          other = 0;
+
+          get bar() {
+            return 1;
+          }
+
+          @action alert() {
+            return 2;
+          }
+
+          <template></template>
+        }
+      `,
+    },
+  ],
+});

--- a/test/eslint-rules/lines-between-class-members.test.mjs
+++ b/test/eslint-rules/lines-between-class-members.test.mjs
@@ -133,7 +133,6 @@ ruleTester.run("lines-between-class-members", rule, {
         { message: "Expected blank line between class members." },
         { message: "Expected blank line between class members." },
         { message: "Expected blank line between class members." },
-        { message: "Expected blank line between class members." },
       ],
       output: `
         class Foo {
@@ -141,7 +140,6 @@ ruleTester.run("lines-between-class-members", rule, {
 
           @tracked counter;
           @tracked text;
-
           other = 0;
 
           get bar() {

--- a/test/eslint-rules/lines-between-class-members.test.mjs
+++ b/test/eslint-rules/lines-between-class-members.test.mjs
@@ -47,8 +47,11 @@ ruleTester.run("lines-between-class-members", rule, {
         class Foo {
           @service bar;
           @service baz;
+          @service("the-q") quux;
           @optionalService hey;
+          @optionalService("yo") hey;
           @controller hello;
+          @controller("greeter") welcome;
 
           <template></template>
         }


### PR DESCRIPTION
An eslint rule based on `@stylistic/js/lines-between-class-members` (see: https://github.com/eslint-stylistic/eslint-stylistic/blob/d6809c910510a4477e01ea248071f0701d0af4ed/packages/eslint-plugin/rules/lines-between-class-members/lines-between-class-members._js_.ts) with imports inlined, and config stuff inlined or removed, and some boilerplate (and ts) deleted.

The code would require more work to be reusable outside our context: configurable decorator names (with support for grouping), configurable modification to “exceptSingleLine” behavior, configurable ability to treat regular fields like one of the decorator groups. Currently those are all built in assumptions.