### PR TITLE
FEATURE: Add `line-after-imports` rule

### DIFF
--- a/lint-configs/eslint-rules/line-after-imports.mjs
+++ b/lint-configs/eslint-rules/line-after-imports.mjs
@@ -1,9 +1,12 @@
-function isTokenOnSameLine(left, right) {
-  return left?.loc?.end.line === right?.loc?.start.line;
-}
+import {
+  findFirstConsecutiveTokenBefore,
+  findLastConsecutiveTokenAfter,
+  getBoundaryTokens,
+  hasTokenOrCommentBetween,
+} from "./utils/tokens";
 
-function isSemicolonToken(token) {
-  return token.value === ";" && token.type === "Punctuator";
+function findLastIndexOfType(nodes, type) {
+  return nodes.findLastIndex((node) => node.type === type);
 }
 
 export default {
@@ -18,71 +21,6 @@ export default {
 
   create(context) {
     const sourceCode = context.sourceCode;
-
-    function findLastIndexOfType(nodes, type) {
-      return nodes.findLastIndex((node) => node.type === type);
-    }
-
-    function findLastConsecutiveTokenAfter(
-      prevLastToken,
-      nextFirstToken,
-      maxLine
-    ) {
-      const after = sourceCode.getTokenAfter(prevLastToken, {
-        includeComments: true,
-      });
-
-      if (
-        after !== nextFirstToken &&
-        after.loc.start.line - prevLastToken.loc.end.line <= maxLine
-      ) {
-        return findLastConsecutiveTokenAfter(after, nextFirstToken, maxLine);
-      }
-
-      return prevLastToken;
-    }
-
-    function findFirstConsecutiveTokenBefore(
-      nextFirstToken,
-      prevLastToken,
-      maxLine
-    ) {
-      const before = sourceCode.getTokenBefore(nextFirstToken, {
-        includeComments: true,
-      });
-
-      if (
-        before !== prevLastToken &&
-        nextFirstToken.loc.start.line - before.loc.end.line <= maxLine
-      ) {
-        return findFirstConsecutiveTokenBefore(before, prevLastToken, maxLine);
-      }
-
-      return nextFirstToken;
-    }
-
-    function getBoundaryTokens(curNode, nextNode) {
-      const lastToken = sourceCode.getLastToken(curNode);
-      const prevToken = sourceCode.getTokenBefore(lastToken);
-      const nextToken = sourceCode.getFirstToken(nextNode); // skip possible lone `;` between nodes
-
-      const isSemicolonLessStyle =
-        isSemicolonToken(lastToken) &&
-        !isTokenOnSameLine(prevToken, lastToken) &&
-        isTokenOnSameLine(lastToken, nextToken);
-
-      return isSemicolonLessStyle
-        ? { curLast: prevToken, nextFirst: lastToken }
-        : { curLast: lastToken, nextFirst: nextToken };
-    }
-
-    function hasTokenOrCommentBetween(before, after) {
-      return (
-        sourceCode.getTokensBetween(before, after, {
-          includeComments: true,
-        }).length !== 0
-      );
-    }
 
     return {
       Program(node) {
@@ -100,16 +38,19 @@ export default {
         }
 
         const { curLast, nextFirst } = getBoundaryTokens(
+          sourceCode,
           body[index],
           body[index + 1]
         );
 
         const beforePadding = findLastConsecutiveTokenAfter(
+          sourceCode,
           curLast,
           nextFirst,
           1
         );
         const afterPadding = findFirstConsecutiveTokenBefore(
+          sourceCode,
           nextFirst,
           curLast,
           1
@@ -117,10 +58,12 @@ export default {
         const isPadded =
           afterPadding.loc.start.line - beforePadding.loc.end.line > 1;
         const hasTokenInPadding = hasTokenOrCommentBetween(
+          sourceCode,
           beforePadding,
           afterPadding
         );
         const curLineLastToken = findLastConsecutiveTokenAfter(
+          sourceCode,
           curLast,
           nextFirst,
           0
@@ -143,80 +86,6 @@ export default {
           },
         });
       },
-
-      // ImportDeclaration(node) {
-      //   const modulePath = node.source.value.toLowerCase();
-
-      //   // todo
-      // },
-
-      // ClassBody(node) {
-      //   const body = node.body;
-
-      //   for (let i = 0; i < body.length - 1; i++) {
-      //     const curFirst = sourceCode.getFirstToken(body[i]);
-      //     const { curLast, nextFirst } = getBoundaryTokens(
-      //       body[i],
-      //       body[i + 1]
-      //     );
-      //     const singleLine = isTokenOnSameLine(curFirst, curLast);
-      //     const skip =
-      //       singleLine && nodeType(body[i]) === nodeType(body[i + 1]);
-      //     const beforePadding = findLastConsecutiveTokenAfter(
-      //       curLast,
-      //       nextFirst,
-      //       1
-      //     );
-      //     const afterPadding = findFirstConsecutiveTokenBefore(
-      //       nextFirst,
-      //       curLast,
-      //       1
-      //     );
-      //     const isPadded =
-      //       afterPadding.loc.start.line - beforePadding.loc.end.line > 1;
-      //     const hasTokenInPadding = hasTokenOrCommentBetween(
-      //       beforePadding,
-      //       afterPadding
-      //     );
-      //     const curLineLastToken = findLastConsecutiveTokenAfter(
-      //       curLast,
-      //       nextFirst,
-      //       0
-      //     );
-      //     const paddingType = getPaddingType(body[i], body[i + 1]);
-
-      //     if (paddingType === "never" && isPadded) {
-      //       context.report({
-      //         node: body[i + 1],
-      //         messageId: "never",
-
-      //         fix(fixer) {
-      //           if (hasTokenInPadding) {
-      //             return null;
-      //           }
-
-      //           return fixer.replaceTextRange(
-      //             [beforePadding.range[1], afterPadding.range[0]],
-      //             "\n"
-      //           );
-      //         },
-      //       });
-      //     } else if (paddingType === "always" && !skip && !isPadded) {
-      //       context.report({
-      //         node: body[i + 1],
-      //         messageId: "always",
-
-      //         fix(fixer) {
-      //           if (hasTokenInPadding) {
-      //             return null;
-      //           }
-
-      //           return fixer.insertTextAfter(curLineLastToken, "\n");
-      //         },
-      //       });
-      //     }
-      //   }
-      // },
     };
   },
 };

--- a/lint-configs/eslint-rules/line-after-imports.mjs
+++ b/lint-configs/eslint-rules/line-after-imports.mjs
@@ -1,0 +1,222 @@
+function isTokenOnSameLine(left, right) {
+  return left?.loc?.end.line === right?.loc?.start.line;
+}
+
+function isSemicolonToken(token) {
+  return token.value === ";" && token.type === "Punctuator";
+}
+
+export default {
+  meta: {
+    type: "layout",
+    docs: {
+      description: "Require an empty line after the imports block",
+    },
+    fixable: "whitespace",
+    schema: [], // no options
+  },
+
+  create(context) {
+    const sourceCode = context.sourceCode;
+
+    function findLastIndexOfType(nodes, type) {
+      return nodes.findLastIndex((node) => node.type === type);
+    }
+
+    function findLastConsecutiveTokenAfter(
+      prevLastToken,
+      nextFirstToken,
+      maxLine
+    ) {
+      const after = sourceCode.getTokenAfter(prevLastToken, {
+        includeComments: true,
+      });
+
+      if (
+        after !== nextFirstToken &&
+        after.loc.start.line - prevLastToken.loc.end.line <= maxLine
+      ) {
+        return findLastConsecutiveTokenAfter(after, nextFirstToken, maxLine);
+      }
+
+      return prevLastToken;
+    }
+
+    function findFirstConsecutiveTokenBefore(
+      nextFirstToken,
+      prevLastToken,
+      maxLine
+    ) {
+      const before = sourceCode.getTokenBefore(nextFirstToken, {
+        includeComments: true,
+      });
+
+      if (
+        before !== prevLastToken &&
+        nextFirstToken.loc.start.line - before.loc.end.line <= maxLine
+      ) {
+        return findFirstConsecutiveTokenBefore(before, prevLastToken, maxLine);
+      }
+
+      return nextFirstToken;
+    }
+
+    function getBoundaryTokens(curNode, nextNode) {
+      const lastToken = sourceCode.getLastToken(curNode);
+      const prevToken = sourceCode.getTokenBefore(lastToken);
+      const nextToken = sourceCode.getFirstToken(nextNode); // skip possible lone `;` between nodes
+
+      const isSemicolonLessStyle =
+        isSemicolonToken(lastToken) &&
+        !isTokenOnSameLine(prevToken, lastToken) &&
+        isTokenOnSameLine(lastToken, nextToken);
+
+      return isSemicolonLessStyle
+        ? { curLast: prevToken, nextFirst: lastToken }
+        : { curLast: lastToken, nextFirst: nextToken };
+    }
+
+    function hasTokenOrCommentBetween(before, after) {
+      return (
+        sourceCode.getTokensBetween(before, after, {
+          includeComments: true,
+        }).length !== 0
+      );
+    }
+
+    return {
+      Program(node) {
+        const body = node.body;
+        const index = findLastIndexOfType(body, "ImportDeclaration");
+
+        if (index === -1) {
+          // No imports
+          return;
+        }
+
+        if (!body[index + 1]) {
+          // Nothing after imports
+          return;
+        }
+
+        const { curLast, nextFirst } = getBoundaryTokens(
+          body[index],
+          body[index + 1]
+        );
+
+        const beforePadding = findLastConsecutiveTokenAfter(
+          curLast,
+          nextFirst,
+          1
+        );
+        const afterPadding = findFirstConsecutiveTokenBefore(
+          nextFirst,
+          curLast,
+          1
+        );
+        const isPadded =
+          afterPadding.loc.start.line - beforePadding.loc.end.line > 1;
+        const hasTokenInPadding = hasTokenOrCommentBetween(
+          beforePadding,
+          afterPadding
+        );
+        const curLineLastToken = findLastConsecutiveTokenAfter(
+          curLast,
+          nextFirst,
+          0
+        );
+
+        if (isPadded) {
+          return;
+        }
+
+        context.report({
+          node: body[index],
+          message: "Expected blank line after imports.",
+
+          fix(fixer) {
+            if (hasTokenInPadding) {
+              return null;
+            }
+
+            return fixer.insertTextAfter(curLineLastToken, "\n");
+          },
+        });
+      },
+
+      // ImportDeclaration(node) {
+      //   const modulePath = node.source.value.toLowerCase();
+
+      //   // todo
+      // },
+
+      // ClassBody(node) {
+      //   const body = node.body;
+
+      //   for (let i = 0; i < body.length - 1; i++) {
+      //     const curFirst = sourceCode.getFirstToken(body[i]);
+      //     const { curLast, nextFirst } = getBoundaryTokens(
+      //       body[i],
+      //       body[i + 1]
+      //     );
+      //     const singleLine = isTokenOnSameLine(curFirst, curLast);
+      //     const skip =
+      //       singleLine && nodeType(body[i]) === nodeType(body[i + 1]);
+      //     const beforePadding = findLastConsecutiveTokenAfter(
+      //       curLast,
+      //       nextFirst,
+      //       1
+      //     );
+      //     const afterPadding = findFirstConsecutiveTokenBefore(
+      //       nextFirst,
+      //       curLast,
+      //       1
+      //     );
+      //     const isPadded =
+      //       afterPadding.loc.start.line - beforePadding.loc.end.line > 1;
+      //     const hasTokenInPadding = hasTokenOrCommentBetween(
+      //       beforePadding,
+      //       afterPadding
+      //     );
+      //     const curLineLastToken = findLastConsecutiveTokenAfter(
+      //       curLast,
+      //       nextFirst,
+      //       0
+      //     );
+      //     const paddingType = getPaddingType(body[i], body[i + 1]);
+
+      //     if (paddingType === "never" && isPadded) {
+      //       context.report({
+      //         node: body[i + 1],
+      //         messageId: "never",
+
+      //         fix(fixer) {
+      //           if (hasTokenInPadding) {
+      //             return null;
+      //           }
+
+      //           return fixer.replaceTextRange(
+      //             [beforePadding.range[1], afterPadding.range[0]],
+      //             "\n"
+      //           );
+      //         },
+      //       });
+      //     } else if (paddingType === "always" && !skip && !isPadded) {
+      //       context.report({
+      //         node: body[i + 1],
+      //         messageId: "always",
+
+      //         fix(fixer) {
+      //           if (hasTokenInPadding) {
+      //             return null;
+      //           }
+
+      //           return fixer.insertTextAfter(curLineLastToken, "\n");
+      //         },
+      //       });
+      //     }
+      //   }
+      // },
+    };
+  },
+};

--- a/lint-configs/eslint-rules/line-after-imports.mjs
+++ b/lint-configs/eslint-rules/line-after-imports.mjs
@@ -3,7 +3,7 @@ import {
   findLastConsecutiveTokenAfter,
   getBoundaryTokens,
   hasTokenOrCommentBetween,
-} from "./utils/tokens";
+} from "./utils/tokens.mjs";
 
 function findLastIndexOfType(nodes, type) {
   return nodes.findLastIndex((node) => node.type === type);

--- a/lint-configs/eslint-rules/lines-between-class-members.mjs
+++ b/lint-configs/eslint-rules/lines-between-class-members.mjs
@@ -4,7 +4,7 @@ import {
   getBoundaryTokens,
   hasTokenOrCommentBetween,
   isTokenOnSameLine,
-} from "./utils/tokens";
+} from "./utils/tokens.mjs";
 
 export default {
   meta: {

--- a/lint-configs/eslint-rules/lines-between-class-members.mjs
+++ b/lint-configs/eslint-rules/lines-between-class-members.mjs
@@ -1,3 +1,6 @@
+// Based on `@stylistic/js/lines-between-class-members`
+// See: https://github.com/eslint-stylistic/eslint-stylistic/blob/d6809c910510a4477e01ea248071f0701d0af4ed/packages/eslint-plugin/rules/lines-between-class-members/lines-between-class-members._js_.ts
+
 import {
   findFirstConsecutiveTokenBefore,
   findLastConsecutiveTokenAfter,

--- a/lint-configs/eslint-rules/lines-between-class-members.mjs
+++ b/lint-configs/eslint-rules/lines-between-class-members.mjs
@@ -1,10 +1,10 @@
-function isTokenOnSameLine(left, right) {
-  return left?.loc?.end.line === right?.loc?.start.line;
-}
-
-function isSemicolonToken(token) {
-  return token.value === ";" && token.type === "Punctuator";
-}
+import {
+  findFirstConsecutiveTokenBefore,
+  findLastConsecutiveTokenAfter,
+  getBoundaryTokens,
+  hasTokenOrCommentBetween,
+  isTokenOnSameLine,
+} from "./utils/tokens";
 
 export default {
   meta: {
@@ -28,115 +28,6 @@ export default {
       { blankLine: "always", prev: "*", next: "template" },
     ];
     const sourceCode = context.sourceCode;
-
-    /**
-     * Gets a pair of tokens that should be used to check lines between two class member nodes.
-     *
-     * In most cases, this returns the very last token of the current node and
-     * the very first token of the next node.
-     * For example:
-     *
-     *     class C {
-     *         x = 1;   // curLast: `;` nextFirst: `in`
-     *         in = 2
-     *     }
-     *
-     * There is only one exception. If the given node ends with a semicolon, and it looks like
-     * a semicolon-less style's semicolon - one that is not on the same line as the preceding
-     * token, but is on the line where the next class member starts - this returns the preceding
-     * token and the semicolon as boundary tokens.
-     * For example:
-     *
-     *     class C {
-     *         x = 1    // curLast: `1` nextFirst: `;`
-     *         ;in = 2
-     *     }
-     * When determining the desired layout of the code, we should treat this semicolon as
-     * a part of the next class member node instead of the one it technically belongs to.
-     * @param curNode Current class member node.
-     * @param nextNode Next class member node.
-     * @returns The actual last token of `node`.
-     * @private
-     */
-    function getBoundaryTokens(curNode, nextNode) {
-      const lastToken = sourceCode.getLastToken(curNode);
-      const prevToken = sourceCode.getTokenBefore(lastToken);
-      const nextToken = sourceCode.getFirstToken(nextNode); // skip possible lone `;` between nodes
-
-      const isSemicolonLessStyle =
-        isSemicolonToken(lastToken) &&
-        !isTokenOnSameLine(prevToken, lastToken) &&
-        isTokenOnSameLine(lastToken, nextToken);
-
-      return isSemicolonLessStyle
-        ? { curLast: prevToken, nextFirst: lastToken }
-        : { curLast: lastToken, nextFirst: nextToken };
-    }
-
-    /**
-     * Return the last token among the consecutive tokens that have no exceed max line difference in between, before the first token in the next member.
-     * @param prevLastToken The last token in the previous member node.
-     * @param nextFirstToken The first token in the next member node.
-     * @param maxLine The maximum number of allowed line difference between consecutive tokens.
-     * @returns  The last token among the consecutive tokens.
-     */
-    function findLastConsecutiveTokenAfter(
-      prevLastToken,
-      nextFirstToken,
-      maxLine
-    ) {
-      const after = sourceCode.getTokenAfter(prevLastToken, {
-        includeComments: true,
-      });
-
-      if (
-        after !== nextFirstToken &&
-        after.loc.start.line - prevLastToken.loc.end.line <= maxLine
-      ) {
-        return findLastConsecutiveTokenAfter(after, nextFirstToken, maxLine);
-      }
-
-      return prevLastToken;
-    }
-
-    /**
-     * Return the first token among the consecutive tokens that have no exceed max line difference in between, after the last token in the previous member.
-     * @param nextFirstToken The first token in the next member node.
-     * @param prevLastToken The last token in the previous member node.
-     * @param maxLine The maximum number of allowed line difference between consecutive tokens.
-     * @returns The first token among the consecutive tokens.
-     */
-    function findFirstConsecutiveTokenBefore(
-      nextFirstToken,
-      prevLastToken,
-      maxLine
-    ) {
-      const before = sourceCode.getTokenBefore(nextFirstToken, {
-        includeComments: true,
-      });
-
-      if (
-        before !== prevLastToken &&
-        nextFirstToken.loc.start.line - before.loc.end.line <= maxLine
-      ) {
-        return findFirstConsecutiveTokenBefore(before, prevLastToken, maxLine);
-      }
-
-      return nextFirstToken;
-    }
-
-    /**
-     * Checks if there is a token or comment between two tokens.
-     * @param before The token before.
-     * @param after The token after.
-     * @returns True if there is a token or comment between two tokens.
-     */
-    function hasTokenOrCommentBetween(before, after) {
-      return (
-        sourceCode.getTokensBetween(before, after, { includeComments: true })
-          .length !== 0
-      );
-    }
 
     /**
      * Returns the type of the node.
@@ -206,6 +97,7 @@ export default {
         for (let i = 0; i < body.length - 1; i++) {
           const curFirst = sourceCode.getFirstToken(body[i]);
           const { curLast, nextFirst } = getBoundaryTokens(
+            sourceCode,
             body[i],
             body[i + 1]
           );
@@ -213,11 +105,13 @@ export default {
           const skip =
             singleLine && nodeType(body[i]) === nodeType(body[i + 1]);
           const beforePadding = findLastConsecutiveTokenAfter(
+            sourceCode,
             curLast,
             nextFirst,
             1
           );
           const afterPadding = findFirstConsecutiveTokenBefore(
+            sourceCode,
             nextFirst,
             curLast,
             1
@@ -225,10 +119,12 @@ export default {
           const isPadded =
             afterPadding.loc.start.line - beforePadding.loc.end.line > 1;
           const hasTokenInPadding = hasTokenOrCommentBetween(
+            sourceCode,
             beforePadding,
             afterPadding
           );
           const curLineLastToken = findLastConsecutiveTokenAfter(
+            sourceCode,
             curLast,
             nextFirst,
             0

--- a/lint-configs/eslint-rules/utils/tokens.mjs
+++ b/lint-configs/eslint-rules/utils/tokens.mjs
@@ -103,7 +103,12 @@ export function findFirstConsecutiveTokenBefore(
     before !== prevLastToken &&
     nextFirstToken.loc.start.line - before.loc.end.line <= maxLine
   ) {
-    return findFirstConsecutiveTokenBefore(before, prevLastToken, maxLine);
+    return findFirstConsecutiveTokenBefore(
+      sourceCode,
+      before,
+      prevLastToken,
+      maxLine
+    );
   }
 
   return nextFirstToken;

--- a/lint-configs/eslint-rules/utils/tokens.mjs
+++ b/lint-configs/eslint-rules/utils/tokens.mjs
@@ -1,0 +1,123 @@
+export function isTokenOnSameLine(left, right) {
+  return left?.loc?.end.line === right?.loc?.start.line;
+}
+
+export function isSemicolonToken(token) {
+  return token.value === ";" && token.type === "Punctuator";
+}
+
+/**
+ * Gets a pair of tokens that should be used to check lines between two class member nodes.
+ *
+ * In most cases, this returns the very last token of the current node and
+ * the very first token of the next node.
+ * For example:
+ *
+ *     class C {
+ *         x = 1;   // curLast: `;` nextFirst: `in`
+ *         in = 2
+ *     }
+ *
+ * There is only one exception. If the given node ends with a semicolon, and it looks like
+ * a semicolon-less style's semicolon - one that is not on the same line as the preceding
+ * token, but is on the line where the next class member starts - this returns the preceding
+ * token and the semicolon as boundary tokens.
+ * For example:
+ *
+ *     class C {
+ *         x = 1    // curLast: `1` nextFirst: `;`
+ *         ;in = 2
+ *     }
+ * When determining the desired layout of the code, we should treat this semicolon as
+ * a part of the next class member node instead of the one it technically belongs to.
+ * @param curNode Current class member node.
+ * @param nextNode Next class member node.
+ * @returns The actual last token of `node`.
+ * @private
+ */
+export function getBoundaryTokens(sourceCode, curNode, nextNode) {
+  const lastToken = sourceCode.getLastToken(curNode);
+  const prevToken = sourceCode.getTokenBefore(lastToken);
+  const nextToken = sourceCode.getFirstToken(nextNode); // skip possible lone `;` between nodes
+
+  const isSemicolonLessStyle =
+    isSemicolonToken(lastToken) &&
+    !isTokenOnSameLine(prevToken, lastToken) &&
+    isTokenOnSameLine(lastToken, nextToken);
+
+  return isSemicolonLessStyle
+    ? { curLast: prevToken, nextFirst: lastToken }
+    : { curLast: lastToken, nextFirst: nextToken };
+}
+
+/**
+ * Return the last token among the consecutive tokens that have no exceed max line difference in between, before the first token in the next member.
+ * @param prevLastToken The last token in the previous member node.
+ * @param nextFirstToken The first token in the next member node.
+ * @param maxLine The maximum number of allowed line difference between consecutive tokens.
+ * @returns  The last token among the consecutive tokens.
+ */
+export function findLastConsecutiveTokenAfter(
+  sourceCode,
+  prevLastToken,
+  nextFirstToken,
+  maxLine
+) {
+  const after = sourceCode.getTokenAfter(prevLastToken, {
+    includeComments: true,
+  });
+
+  if (
+    after !== nextFirstToken &&
+    after.loc.start.line - prevLastToken.loc.end.line <= maxLine
+  ) {
+    return findLastConsecutiveTokenAfter(
+      sourceCode,
+      after,
+      nextFirstToken,
+      maxLine
+    );
+  }
+
+  return prevLastToken;
+}
+
+/**
+ * Return the first token among the consecutive tokens that have no exceed max line difference in between, after the last token in the previous member.
+ * @param nextFirstToken The first token in the next member node.
+ * @param prevLastToken The last token in the previous member node.
+ * @param maxLine The maximum number of allowed line difference between consecutive tokens.
+ * @returns The first token among the consecutive tokens.
+ */
+export function findFirstConsecutiveTokenBefore(
+  sourceCode,
+  nextFirstToken,
+  prevLastToken,
+  maxLine
+) {
+  const before = sourceCode.getTokenBefore(nextFirstToken, {
+    includeComments: true,
+  });
+
+  if (
+    before !== prevLastToken &&
+    nextFirstToken.loc.start.line - before.loc.end.line <= maxLine
+  ) {
+    return findFirstConsecutiveTokenBefore(before, prevLastToken, maxLine);
+  }
+
+  return nextFirstToken;
+}
+
+/**
+ * Checks if there is a token or comment between two tokens.
+ * @param before The token before.
+ * @param after The token after.
+ * @returns True if there is a token or comment between two tokens.
+ */
+export function hasTokenOrCommentBetween(sourceCode, before, after) {
+  return (
+    sourceCode.getTokensBetween(before, after, { includeComments: true })
+      .length !== 0
+  );
+}

--- a/lint-configs/eslint.config.mjs
+++ b/lint-configs/eslint.config.mjs
@@ -1,2 +1,3 @@
 import DiscourseRecommended from "./eslint.mjs";
+
 export default DiscourseRecommended;

--- a/lint-configs/eslint.mjs
+++ b/lint-configs/eslint.mjs
@@ -284,7 +284,7 @@ export default [
       "discourse/no-simple-queryselector": ["error"],
       "discourse/deprecated-lookups": ["error"],
       "discourse/discourse-common-imports": ["error"],
-      // "discourse/lines-between-class-members": ["error"],
+      "discourse/lines-between-class-members": ["error"],
       "discourse/line-after-imports": ["error"],
     },
   },

--- a/lint-configs/eslint.mjs
+++ b/lint-configs/eslint.mjs
@@ -16,6 +16,7 @@ import deprecatedLookups from "./eslint-rules/deprecated-lookups.mjs";
 import discourseCommonImports from "./eslint-rules/discourse-common-imports.mjs";
 import i18nImport from "./eslint-rules/i18n-import-location.mjs";
 import i18nT from "./eslint-rules/i18n-t.mjs";
+import lineAfterImports from "./eslint-rules/line-after-imports.mjs";
 import linesBetweenClassMembers from "./eslint-rules/lines-between-class-members.mjs";
 import noSimpleQueryselector from "./eslint-rules/no-simple-queryselector.mjs";
 import serviceInjectImport from "./eslint-rules/service-inject-import.mjs";
@@ -111,6 +112,7 @@ export default [
           "deprecated-lookups": deprecatedLookups,
           "discourse-common-imports": discourseCommonImports,
           "lines-between-class-members": linesBetweenClassMembers,
+          "line-after-imports": lineAfterImports,
         },
       },
     },
@@ -282,7 +284,8 @@ export default [
       "discourse/no-simple-queryselector": ["error"],
       "discourse/deprecated-lookups": ["error"],
       "discourse/discourse-common-imports": ["error"],
-      "discourse/lines-between-class-members": ["error"],
+      // "discourse/lines-between-class-members": ["error"],
+      "discourse/line-after-imports": ["error"],
     },
   },
   {

--- a/test/eslint-rules/line-after-imports.test.mjs
+++ b/test/eslint-rules/line-after-imports.test.mjs
@@ -1,0 +1,56 @@
+import { RuleTester } from "eslint";
+import rule from "../../lint-configs/eslint-rules/line-after-imports.mjs";
+
+const ruleTester = new RuleTester({
+  languageOptions: { ecmaVersion: 2018 },
+});
+
+ruleTester.run("line-after-imports", rule, {
+  valid: [
+    {
+      code: `
+        import x from "foo";
+
+        class Y {}
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        import x from "foo";
+        import z from "bar";
+        // test
+        class Y {}
+      `,
+      errors: [{ message: "Expected blank line after imports." }],
+      output: `
+        import x from "foo";
+        import z from "bar";
+
+        // test
+        class Y {}
+      `,
+    },
+    {
+      code: `
+        import x from "foo";
+        const xCopy = x;
+        import z from "bar";
+        const STRING = "hey";
+        // test
+        class Y {}
+      `,
+      errors: [{ message: "Expected blank line after imports." }],
+      output: `
+        import x from "foo";
+        const xCopy = x;
+        import z from "bar";
+
+        const STRING = "hey";
+        // test
+        class Y {}
+      `,
+    },
+  ],
+});


### PR DESCRIPTION
Ensures a blank line after the last `import`:

invalid:

```js
import x from "foo";
const xCopy = x;
import z from "bar";
const STRING = "hey";
// test
class Y {}
```

valid:

```js
import x from "foo";
const xCopy = x;
import z from "bar";

const STRING = "hey";
// test
class Y {}
```