### PR TITLE
Switch stylelint media-feature-range-notation rule to default "context"

### DIFF
--- a/lint-configs/package.json
+++ b/lint-configs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@discourse/lint-configs",
-  "version": "2.11.2",
+  "version": "2.12.0",
   "description": "Shareable lint configs for Discourse core, plugins, and themes",
   "author": "Discourse",
   "license": "MIT",

--- a/lint-configs/stylelint.mjs
+++ b/lint-configs/stylelint.mjs
@@ -26,6 +26,5 @@ export default {
     "scss/at-function-pattern": null,
     "scss/comment-no-empty": null,
     "scss/at-mixin-pattern": null,
-    "media-feature-range-notation": "prefix",
   },
 };


### PR DESCRIPTION
Modern versions of Discourse core run stylelint, which will polyfill this modern syntax for older browsers. Ref https://github.com/discourse/discourse/pull/31885