### PR TITLE
Handle decorators in line-before-default-export

### DIFF
--- a/lint-configs/package.json
+++ b/lint-configs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@discourse/lint-configs",
-  "version": "2.17.0",
+  "version": "2.17.1",
   "description": "Shareable lint configs for Discourse core, plugins, and themes",
   "author": "Discourse",
   "license": "MIT",

--- a/test/eslint-rules/line-before-default-export.test.mjs
+++ b/test/eslint-rules/line-before-default-export.test.mjs
@@ -17,6 +17,14 @@ ruleTester.run("line-before-default-export", rule, {
         export default Foo;
       `,
     },
+    {
+      code: `
+        const A = "b";
+
+        @className("foo")
+        export default class Foo {};
+      `,
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
Also switched from the `Program` hook to the `ExportDefaultDeclaration` hook, which I think should be slightly faster