### PR TITLE
DEV: enable no-mixins and no-new-mixins ember linting rules

### DIFF
--- a/lint-configs/eslint.mjs
+++ b/lint-configs/eslint.mjs
@@ -190,8 +190,6 @@ export default [
       "ember/avoid-leaking-state-in-ember-objects": "off",
       "ember/no-get": "off",
       "ember/no-observers": "off",
-      "ember/no-mixins": "off",
-      "ember/no-new-mixins": "off",
       "ember/no-implicit-injections": "off", // this rule is broken
       "ember/no-array-prototype-extensions": "off",
       "ember/no-at-ember-render-modifiers": "off",

--- a/lint-configs/package.json
+++ b/lint-configs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@discourse/lint-configs",
-  "version": "2.21.0",
+  "version": "2.22.0",
   "description": "Shareable lint configs for Discourse core, plugins, and themes",
   "author": "Discourse",
   "license": "MIT",


### PR DESCRIPTION
With the removal of ember mixins from repos under the discourse org, we are now enabling these 2 linting rules.

https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-mixins.md
https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-new-mixins.md

