### PR TITLE
DEV: Add `no-computed-macros` ESLint rule

### DIFF
--- a/lint-configs/eslint-rules/i18n-import-location.mjs
+++ b/lint-configs/eslint-rules/i18n-import-location.mjs
@@ -1,4 +1,4 @@
-import { fixImport } from "./utils/fix-import.mjs";
+import { buildImportStatement, fixImport } from "./utils/fix-import.mjs";
 
 export default {
   meta: {
@@ -43,13 +43,11 @@ export default {
 
               const localName = node.specifiers[0].local.name;
               let sourceName = node.source.value.match(/([^/]+)$/)[0];
-              let importString;
 
-              if (localName === sourceName) {
-                importString = `${localName}`;
-              } else {
-                importString = `${sourceName} as ${localName}`;
-              }
+              const namedImport =
+                localName === sourceName
+                  ? localName
+                  : `${sourceName} as ${localName}`;
 
               const existingImport = context
                 .getSourceCode()
@@ -63,13 +61,15 @@ export default {
                 return [
                   fixer.remove(node),
                   fixImport(fixer, existingImport, {
-                    namedImportsToAdd: [importString],
+                    namedImportsToAdd: [namedImport],
                   }),
                 ];
               } else {
                 return fixer.replaceText(
                   node,
-                  `import { ${importString} } from "discourse-i18n";`
+                  buildImportStatement("discourse-i18n", {
+                    namedImports: [namedImport],
+                  })
                 );
               }
             },

--- a/lint-configs/eslint-rules/no-computed-macros.mjs
+++ b/lint-configs/eslint-rules/no-computed-macros.mjs
@@ -1,0 +1,373 @@
+/**
+ * @fileoverview ESLint rule to replace computed property macro decorators
+ * from `@ember/object/computed` and `discourse/lib/computed` with native
+ * getters using `@computed` or `@dependentKeyCompat` + `@tracked`.
+ */
+
+import { analyzeMacroUsage } from "./no-computed-macros/computed-macros-analysis.mjs";
+import { createMacroFix } from "./no-computed-macros/computed-macros-fixer.mjs";
+import { MACRO_SOURCES } from "./no-computed-macros/macro-transforms.mjs";
+import {
+  collectImports,
+  getImportedLocalNames,
+} from "./utils/analyze-imports.mjs";
+import { buildImportStatement, fixImport } from "./utils/fix-import.mjs";
+
+export default {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Replace computed property macros with native getters",
+    },
+    fixable: "code",
+    schema: [],
+    messages: {
+      replaceMacro: "Replace '@{{name}}' macro with a native getter.",
+      cannotAutoFixClassic:
+        "Cannot auto-fix '{{name}}' in a classic .extend() class. Convert to native ES6 class first.",
+      cannotAutoFixComplex: "Cannot auto-fix '{{name}}': {{reason}}.",
+      cannotAutoFixDynamic:
+        "Cannot auto-fix '@{{name}}' because it has non-literal arguments.",
+      cannotAutoFixSelfReference:
+        "Cannot auto-fix '@{{name}}' because property '{{propName}}' references itself.",
+    },
+  },
+
+  create(context) {
+    const sourceCode = context.getSourceCode();
+    let analysis = null;
+    let importsMap = null;
+    let importFixGenerated = false;
+
+    function ensureAnalysis() {
+      if (analysis) {
+        return analysis;
+      }
+      importsMap = collectImports(sourceCode);
+      analysis = analyzeMacroUsage(sourceCode, importsMap);
+      return analysis;
+    }
+
+    return {
+      // Report on macro import declarations — only the import-level fix here
+      ImportDeclaration(node) {
+        if (!MACRO_SOURCES.has(node.source.value)) {
+          return;
+        }
+
+        const { usages, importedMacros, macroImportNodes } = ensureAnalysis();
+
+        const macroSpecifiers = node.specifiers.filter(
+          (spec) =>
+            spec.type === "ImportSpecifier" &&
+            importedMacros.has(spec.local.name)
+        );
+
+        if (macroSpecifiers.length === 0) {
+          return;
+        }
+
+        const fixableUsages = usages.filter((u) => u.canAutoFix);
+        const hasAnyFix = fixableUsages.length > 0;
+
+        // Build the import fix ONCE across all macro import declarations.
+        // When a file imports from both @ember/object/computed and
+        // discourse/lib/computed, we must handle all import nodes in a
+        // single fix to avoid duplicate new import lines.
+        let importFix;
+        if (hasAnyFix && !importFixGenerated) {
+          importFixGenerated = true;
+          importFix = (fixer) =>
+            buildImportFixes(fixer, {
+              sourceCode,
+              importsMap,
+              usages: fixableUsages,
+              macroImportNodes,
+            });
+        }
+
+        let fixAttached = false;
+        for (const spec of macroSpecifiers) {
+          const macroName = importedMacros.get(spec.local.name);
+          context.report({
+            node: spec,
+            messageId: "replaceMacro",
+            data: { name: macroName },
+            fix: !fixAttached ? importFix : undefined,
+          });
+          fixAttached = true;
+        }
+      },
+
+      // Report on each macro usage in class bodies
+      PropertyDefinition(node) {
+        if (!node.decorators) {
+          return;
+        }
+
+        const { usages } = ensureAnalysis();
+        const usage = usages.find((u) => u.propertyNode === node);
+
+        if (!usage) {
+          return;
+        }
+
+        context.report({
+          node: usage.decoratorNode || node,
+          messageId: usage.messageId || "replaceMacro",
+          data: usage.reportData || { name: usage.macroName },
+          fix: usage.canAutoFix ? createMacroFix(usage, sourceCode) : undefined,
+        });
+      },
+
+      // Report on classic .extend() usage
+      CallExpression(node) {
+        const { usages } = ensureAnalysis();
+
+        for (const usage of usages) {
+          if (
+            usage.messageId === "cannotAutoFixClassic" &&
+            usage.propertyNode?.parent === node.arguments?.[0]
+          ) {
+            context.report({
+              node: usage.propertyNode,
+              messageId: usage.messageId,
+              data: usage.reportData,
+            });
+          }
+        }
+      },
+    };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Import fix builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Build import-related fixes for ALL fixable macro usages.
+ *
+ * This function handles ALL macro import nodes at once to avoid producing
+ * duplicate new import lines when a file imports macros from both
+ * `@ember/object/computed` and `discourse/lib/computed`.
+ *
+ * It also handles adding `@tracked` to existing class members that need it.
+ * This is done here (rather than per-usage in the property fixer) so that
+ * each member is decorated exactly once, even when multiple macros reference
+ * the same dependency.
+ *
+ * @returns {import('eslint').Rule.Fix[]}
+ */
+function buildImportFixes(
+  fixer,
+  { sourceCode, importsMap, usages, macroImportNodes }
+) {
+  const fixes = [];
+  const allImportedNames = getImportedLocalNames(sourceCode);
+
+  // Exclude names we're about to remove from the collision set
+  const fixableLocalNames = new Set(usages.map((u) => u.localName));
+  for (const name of fixableLocalNames) {
+    allImportedNames.delete(name);
+  }
+
+  // Collect all required new imports from fixable usages
+  const newImports = collectRequiredImports(usages);
+
+  // Determine conditional imports based on dep classification
+  const needsComputed = usages.some((u) => !u.allLocal);
+  const needsDependentKeyCompat = usages.some((u) => u.allLocal);
+  const needsTracked = usages.some(
+    (u) =>
+      u.allLocal &&
+      (u.trackedDeps?.length > 0 || u.existingNodesToDecorate?.length > 0)
+  );
+
+  // Add in the order we want them to appear in the output
+  if (needsTracked) {
+    addToImportSet(newImports, "@glimmer/tracking", "tracked");
+  }
+  if (needsComputed) {
+    addToImportSet(newImports, "@ember/object", "computed");
+  }
+  if (needsDependentKeyCompat) {
+    addToImportSet(newImports, "@ember/object/compat", "dependentKeyCompat");
+  }
+
+  // Build new import lines for required imports (once for all macro sources)
+  const newImportLines = [];
+  for (const [source, names] of newImports) {
+    const existing = importsMap.get(source);
+
+    if (existing) {
+      // Modify existing import — generate a fixImport call
+      const existingNamedSet = new Set(
+        existing.specifiers
+          .filter((s) => s.type === "ImportSpecifier")
+          .map((s) => s.imported.name)
+      );
+      const defaultSpec = existing.specifiers.find(
+        (s) => s.type === "ImportDefaultSpecifier"
+      );
+
+      const namedToAdd = [];
+      let defaultToAdd;
+
+      for (const { name, isDefault } of names) {
+        if (isDefault) {
+          if (!defaultSpec) {
+            defaultToAdd = name;
+          }
+        } else if (!existingNamedSet.has(name)) {
+          const localName = allImportedNames.has(name) ? `${name}Import` : name;
+          namedToAdd.push(
+            localName === name ? name : `${name} as ${localName}`
+          );
+        }
+      }
+
+      if (namedToAdd.length > 0 || defaultToAdd) {
+        fixes.push(
+          fixImport(fixer, existing.node, {
+            defaultImport: defaultToAdd,
+            namedImportsToAdd: namedToAdd,
+          })
+        );
+      }
+    } else {
+      // Build a new import line string (will be appended below)
+      newImportLines.push(
+        resolveNewImportLine(source, names, allImportedNames)
+      );
+    }
+  }
+
+  // Process each macro import node — remove/replace specifiers
+  let newImportsPlaced = false;
+  for (const [, importNode] of macroImportNodes) {
+    const removableSpecifiers = importNode.specifiers.filter(
+      (spec) =>
+        spec.type === "ImportSpecifier" &&
+        fixableLocalNames.has(spec.local.name) &&
+        usages
+          .filter((u) => u.localName === spec.local.name)
+          .every((u) => u.canAutoFix)
+    );
+    const remainingSpecifiers = importNode.specifiers.filter(
+      (s) => !removableSpecifiers.includes(s)
+    );
+
+    if (removableSpecifiers.length === 0) {
+      continue;
+    }
+
+    if (remainingSpecifiers.length === 0) {
+      // All specifiers removed — replace with new imports or remove entirely
+      if (!newImportsPlaced && newImportLines.length > 0) {
+        fixes.push(fixer.replaceText(importNode, newImportLines.join("\n")));
+        newImportsPlaced = true;
+      } else {
+        // Remove the entire import line (including trailing newline)
+        const text = sourceCode.getText();
+        let end = importNode.range[1];
+        if (end < text.length && text[end] === "\n") {
+          end++;
+        }
+        fixes.push(fixer.removeRange([importNode.range[0], end]));
+      }
+    } else {
+      // Some specifiers remain — remove fixable ones
+      const namesToRemove = removableSpecifiers.map((s) => s.imported.name);
+      fixes.push(
+        fixImport(fixer, importNode, {
+          namedImportsToRemove: namesToRemove,
+        })
+      );
+
+      // Append new import lines after this import (only once)
+      if (!newImportsPlaced && newImportLines.length > 0) {
+        for (const line of newImportLines) {
+          fixes.push(fixer.insertTextAfter(importNode, `\n${line}`));
+        }
+        newImportsPlaced = true;
+      }
+    }
+  }
+
+  // Add @tracked to existing class members that need it.
+  // Collecting into a Set deduplicates naturally — no per-usage hack needed.
+  const nodesToDecorate = new Set();
+  for (const usage of usages) {
+    if (usage.existingNodesToDecorate) {
+      for (const node of usage.existingNodesToDecorate) {
+        nodesToDecorate.add(node);
+      }
+    }
+  }
+  for (const memberNode of nodesToDecorate) {
+    fixes.push(fixer.insertTextBefore(memberNode, "@tracked "));
+  }
+
+  return fixes;
+}
+
+/**
+ * Resolve import names (handling collisions) and delegate to
+ * the shared `buildImportStatement` utility.
+ *
+ * @param {string} source
+ * @param {Array<{name: string, isDefault?: boolean}>} names
+ * @param {Set<string>} allImportedNames
+ * @returns {string}
+ */
+function resolveNewImportLine(source, names, allImportedNames) {
+  const namedImports = [];
+  let defaultImport;
+
+  for (const { name, isDefault } of names) {
+    if (isDefault) {
+      defaultImport = name;
+    } else {
+      const localName = allImportedNames.has(name) ? `${name}Import` : name;
+      namedImports.push(localName === name ? name : `${name} as ${localName}`);
+    }
+  }
+
+  return buildImportStatement(source, { defaultImport, namedImports });
+}
+
+// ---------------------------------------------------------------------------
+// Import helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Collect all required imports from fixable usages into a Map.
+ */
+function collectRequiredImports(usages) {
+  const result = new Map();
+
+  for (const usage of usages) {
+    if (!usage.canAutoFix || !usage.transform.requiredImports) {
+      continue;
+    }
+    for (const req of usage.transform.requiredImports) {
+      addToImportSet(result, req.source, req.name, req.isDefault);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Add a named or default import to the import set, avoiding duplicates.
+ */
+function addToImportSet(importSet, source, name, isDefault = false) {
+  if (!importSet.has(source)) {
+    importSet.set(source, []);
+  }
+  const list = importSet.get(source);
+  if (!list.some((i) => i.name === name && i.isDefault === isDefault)) {
+    list.push({ name, isDefault });
+  }
+}

--- a/lint-configs/eslint-rules/no-computed-macros.mjs
+++ b/lint-configs/eslint-rules/no-computed-macros.mjs
@@ -247,8 +247,9 @@ function buildImportFixes(
   const needsDependentKeyCompat = usages.some((u) => u.allLocal);
   const needsTracked = usages.some(
     (u) =>
-      u.allLocal &&
-      (u.trackedDeps?.length > 0 || u.existingNodesToDecorate?.length > 0)
+      (u.allLocal &&
+        (u.trackedDeps?.length > 0 || u.existingNodesToDecorate?.length > 0)) ||
+      u.transform.overrideTrackedFields
   );
 
   // Add in the order we want them to appear in the output

--- a/lint-configs/eslint-rules/no-computed-macros.mjs
+++ b/lint-configs/eslint-rules/no-computed-macros.mjs
@@ -258,6 +258,15 @@ function buildImportFixes(
   if (needsComputed) {
     addToImportSet(newImports, "@ember/object", "computed");
   }
+  // Setter-specific imports (e.g. set from @ember/object for alias).
+  // Added after computed so that named imports appear in the right order.
+  for (const usage of usages) {
+    if (!usage.allLocal && usage.transform.setterRequiredImports) {
+      for (const req of usage.transform.setterRequiredImports) {
+        addToImportSet(newImports, req.source, req.name, req.isDefault);
+      }
+    }
+  }
   if (needsDependentKeyCompat) {
     addToImportSet(newImports, "@ember/object/compat", "dependentKeyCompat");
   }

--- a/lint-configs/eslint-rules/no-computed-macros.mjs
+++ b/lint-configs/eslint-rules/no-computed-macros.mjs
@@ -13,6 +13,8 @@ import {
 } from "./utils/analyze-imports.mjs";
 import { buildImportStatement, fixImport } from "./utils/fix-import.mjs";
 
+const USE_NATIVE_GETTER_INSTEAD = "Use a native getter instead of `@{{name}}`";
+
 export default {
   meta: {
     type: "suggestion",
@@ -22,14 +24,12 @@ export default {
     fixable: "code",
     schema: [],
     messages: {
-      replaceMacro: "Replace '@{{name}}' macro with a native getter.",
+      replaceMacro: `${USE_NATIVE_GETTER_INSTEAD}.`,
       addTracked:
-        "Add @tracked to '{{name}}' (dependency of a converted macro).",
-      cannotAutoFixComplex: "Cannot auto-fix '{{name}}': {{reason}}.",
-      cannotAutoFixDynamic:
-        "Cannot auto-fix '@{{name}}' because it has non-literal arguments.",
-      cannotAutoFixSelfReference:
-        "Cannot auto-fix '@{{name}}' because property '{{propName}}' references itself.",
+        "Add `@tracked` to `{{name}}` (dependency of a converted macro).",
+      cannotAutoFixComplex: `${USE_NATIVE_GETTER_INSTEAD}: {{reason}}.`,
+      cannotAutoFixDynamic: `${USE_NATIVE_GETTER_INSTEAD}: it has non-literal arguments (convert manually).`,
+      cannotAutoFixSelfReference: `${USE_NATIVE_GETTER_INSTEAD}: \`{{propName}}\` references itself (convert manually).`,
     },
   },
 

--- a/lint-configs/eslint-rules/no-computed-macros/computed-macros-analysis.mjs
+++ b/lint-configs/eslint-rules/no-computed-macros/computed-macros-analysis.mjs
@@ -1,0 +1,526 @@
+/**
+ * @fileoverview Analysis helpers for the `no-computed-macros` ESLint rule.
+ *
+ * Performs read-only AST traversal to detect usages of computed property macros
+ * from `@ember/object/computed` and `discourse/lib/computed`, determines whether
+ * each usage can be auto-fixed, and collects the information the fixer needs.
+ */
+
+import { isLocalKey, MACRO_TRANSFORMS } from "./macro-transforms.mjs";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * @typedef {Object} MacroUsage
+ * @property {string} macroName - The original macro name (e.g. "alias", "not")
+ * @property {string} localName - The local identifier name (may differ due to aliases)
+ * @property {import('./macro-transforms.mjs').MacroTransform} transform
+ * @property {import('estree').Node} decoratorNode - The Decorator AST node
+ * @property {import('estree').Node} propertyNode - The PropertyDefinition AST node
+ * @property {string[]} literalArgs - Literal string/number argument values
+ * @property {import('estree').Node[]} argNodes - Raw AST argument nodes
+ * @property {string} propName - The decorated property name
+ * @property {string[]} dependentKeys - Resolved dependent keys
+ * @property {boolean} allLocal - Whether all dependent keys are local (no dots)
+ * @property {boolean} canAutoFix
+ * @property {string} [messageId] - Message ID when not auto-fixable
+ * @property {Object} [reportData] - Data for error message interpolation
+ * @property {string[]} [trackedDeps] - Local deps needing a NEW @tracked declaration (not existing members)
+ * @property {import('estree').Node[]} [existingNodesToDecorate] - Existing PropertyDefinition nodes needing @tracked added
+ */
+
+/**
+ * @typedef {Object} MacroAnalysisResult
+ * @property {MacroUsage[]} usages - All detected macro usages
+ * @property {Map<string, string>} importedMacros - Map from local name → macro name
+ * @property {Map<string, import('estree').ImportDeclaration>} macroImportNodes - Import nodes by source
+ */
+
+// ---------------------------------------------------------------------------
+// Analysis
+// ---------------------------------------------------------------------------
+
+/**
+ * Analyze the source AST for computed property macro usage.
+ *
+ * @param {import('eslint').SourceCode} sourceCode
+ * @param {Map<string, {node: import('estree').ImportDeclaration, specifiers: Array}>} imports
+ *   Result of `collectImports(sourceCode)`.
+ * @returns {MacroAnalysisResult}
+ */
+export function analyzeMacroUsage(sourceCode, imports) {
+  const importedMacros = collectMacroImports(imports);
+  const macroImportNodes = collectMacroImportNodes(imports);
+  const usages = [];
+
+  if (importedMacros.size === 0) {
+    return { usages, importedMacros, macroImportNodes };
+  }
+
+  for (const statement of sourceCode.ast.body) {
+    walkNode(statement, (node) => {
+      // Decorator usage on a PropertyDefinition in a native class
+      if (node.type === "PropertyDefinition" && node.decorators) {
+        analyzePropertyDefinition(node, importedMacros, usages, sourceCode);
+      }
+
+      // Classic .extend() usage — report but don't fix
+      if (isExtendCall(node)) {
+        analyzeExtendCall(node, importedMacros, usages);
+      }
+    });
+  }
+
+  // Deduplicate tracked deps across usages so that each dep/node is
+  // only inserted/decorated by ONE usage's fixer (the first one encountered).
+  deduplicateTrackedDeps(usages);
+
+  return { usages, importedMacros, macroImportNodes };
+}
+
+// ---------------------------------------------------------------------------
+// Import collection
+// ---------------------------------------------------------------------------
+
+/**
+ * Scan the imports map for macro names from both target sources.
+ * Returns a map from local identifier name → canonical macro name.
+ *
+ * @param {Map<string, {node: import('estree').ImportDeclaration, specifiers: Array}>} imports
+ * @returns {Map<string, string>}
+ */
+function collectMacroImports(imports) {
+  const result = new Map();
+
+  for (const [, transform] of MACRO_TRANSFORMS) {
+    const importInfo = imports.get(transform.source);
+    if (!importInfo) {
+      continue;
+    }
+
+    for (const spec of importInfo.specifiers) {
+      if (spec.type !== "ImportSpecifier") {
+        continue;
+      }
+      const importedName = spec.imported.name;
+      if (MACRO_TRANSFORMS.has(importedName)) {
+        result.set(spec.local.name, importedName);
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Collect the ImportDeclaration nodes for each macro source that has macros.
+ *
+ * @param {Map<string, {node: import('estree').ImportDeclaration, specifiers: Array}>} imports
+ * @returns {Map<string, import('estree').ImportDeclaration>}
+ */
+function collectMacroImportNodes(imports) {
+  const result = new Map();
+
+  for (const source of ["@ember/object/computed", "discourse/lib/computed"]) {
+    const importInfo = imports.get(source);
+    if (importInfo) {
+      result.set(source, importInfo.node);
+    }
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// PropertyDefinition analysis (native class decorators)
+// ---------------------------------------------------------------------------
+
+/**
+ * Analyze a PropertyDefinition node for macro decorator usage.
+ *
+ * @param {import('estree').Node} node - PropertyDefinition
+ * @param {Map<string, string>} importedMacros
+ * @param {MacroUsage[]} usages
+ * @param {import('eslint').SourceCode} sourceCode
+ */
+function analyzePropertyDefinition(node, importedMacros, usages, sourceCode) {
+  for (const decorator of node.decorators) {
+    const expr = decorator.expression;
+
+    // Must be a CallExpression — e.g. @alias("foo")
+    if (expr.type !== "CallExpression") {
+      continue;
+    }
+
+    const callee = expr.callee;
+    if (callee.type !== "Identifier") {
+      continue;
+    }
+
+    const macroName = importedMacros.get(callee.name);
+    if (!macroName) {
+      continue;
+    }
+
+    const transform = MACRO_TRANSFORMS.get(macroName);
+    if (!transform) {
+      continue;
+    }
+
+    const propName =
+      node.key.type === "Identifier" ? node.key.name : String(node.key.value);
+
+    const usage = buildUsage({
+      macroName,
+      localName: callee.name,
+      transform,
+      decoratorNode: decorator,
+      propertyNode: node,
+      argNodes: expr.arguments,
+      propName,
+      sourceCode,
+    });
+
+    usages.push(usage);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Classic .extend() analysis
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether a node is a `.extend()` call on a known Ember base class.
+ *
+ * @param {import('estree').Node} node
+ * @returns {boolean}
+ */
+function isExtendCall(node) {
+  return (
+    node.type === "CallExpression" &&
+    node.callee?.type === "MemberExpression" &&
+    node.callee.property?.name === "extend"
+  );
+}
+
+/**
+ * Analyze properties inside a `.extend({...})` call for macro usage.
+ *
+ * @param {import('estree').Node} node - CallExpression for .extend()
+ * @param {Map<string, string>} importedMacros
+ * @param {MacroUsage[]} usages
+ */
+function analyzeExtendCall(node, importedMacros, usages) {
+  for (const arg of node.arguments) {
+    if (arg.type !== "ObjectExpression") {
+      continue;
+    }
+
+    for (const prop of arg.properties) {
+      if (prop.type !== "Property" || !prop.value) {
+        continue;
+      }
+
+      const callExpr = prop.value;
+      if (callExpr.type !== "CallExpression") {
+        continue;
+      }
+
+      const callee = callExpr.callee;
+      if (callee?.type !== "Identifier") {
+        continue;
+      }
+
+      const macroName = importedMacros.get(callee.name);
+      if (!macroName) {
+        continue;
+      }
+
+      const propName =
+        prop.key.type === "Identifier" ? prop.key.name : String(prop.key.value);
+
+      usages.push({
+        macroName,
+        localName: callee.name,
+        transform: MACRO_TRANSFORMS.get(macroName),
+        decoratorNode: null,
+        propertyNode: prop,
+        literalArgs: [],
+        argNodes: callExpr.arguments,
+        propName,
+        dependentKeys: [],
+        allLocal: false,
+        canAutoFix: false,
+        messageId: "cannotAutoFixClassic",
+        reportData: { name: macroName },
+      });
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Usage builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a MacroUsage object from the gathered information, determining
+ * fixability and computing dependent keys.
+ *
+ * @param {Object} params
+ * @returns {MacroUsage}
+ */
+function buildUsage({
+  macroName,
+  localName,
+  transform,
+  decoratorNode,
+  propertyNode,
+  argNodes,
+  propName,
+  sourceCode,
+}) {
+  const base = {
+    macroName,
+    localName,
+    transform,
+    decoratorNode,
+    propertyNode,
+    argNodes,
+    propName,
+    sourceCode,
+  };
+
+  // Not auto-fixable by design (e.g. filter/map with callbacks)
+  if (!transform.canAutoFix) {
+    return {
+      ...base,
+      literalArgs: [],
+      dependentKeys: [],
+      allLocal: false,
+      canAutoFix: false,
+      messageId: "cannotAutoFixComplex",
+      reportData: { name: macroName, reason: transform.reason },
+    };
+  }
+
+  // Extract literal arguments; bail if any arg is non-literal when we need
+  // string args (all macros except match, which has a regex second arg)
+  const literalArgs = [];
+  for (let i = 0; i < argNodes.length; i++) {
+    const argNode = argNodes[i];
+
+    if (argNode.type === "Literal" && typeof argNode.value === "string") {
+      literalArgs.push(argNode.value);
+    } else if (
+      argNode.type === "Literal" &&
+      (typeof argNode.value === "number" || typeof argNode.value === "boolean")
+    ) {
+      literalArgs.push(argNode.value);
+    } else if (argNode.type === "Literal" && argNode.regex) {
+      // Regex literal — allowed for `match`
+      literalArgs.push(argNode.raw);
+    } else if (
+      argNode.type === "TemplateLiteral" &&
+      argNode.expressions.length === 0
+    ) {
+      // Static template literal like `foo`
+      literalArgs.push(argNode.quasis[0].value.cooked);
+    } else {
+      // Non-literal argument → can't auto-fix
+      return {
+        ...base,
+        literalArgs,
+        dependentKeys: [],
+        allLocal: false,
+        canAutoFix: false,
+        messageId: "cannotAutoFixDynamic",
+        reportData: { name: macroName },
+      };
+    }
+  }
+
+  // Build transform args
+  const transformArgs = { literalArgs, argNodes, propName, sourceCode };
+
+  // Compute dependent keys
+  const dependentKeys = transform.toDependentKeys(transformArgs);
+
+  // Check for self-referencing getter
+  const depPaths = dependentKeys.map((k) => k.split(".")[0]);
+  if (depPaths.includes(propName)) {
+    return {
+      ...base,
+      literalArgs,
+      dependentKeys,
+      allLocal: false,
+      canAutoFix: false,
+      messageId: "cannotAutoFixSelfReference",
+      reportData: { name: macroName, propName },
+    };
+  }
+
+  const allLocal = dependentKeys.every(isLocalKey);
+
+  // Determine which local deps need @tracked
+  let trackedDeps;
+  let existingNodesToDecorate;
+  if (allLocal) {
+    const info = findDepsNeedingTracked(propertyNode, dependentKeys);
+    trackedDeps = info.depsToInsert;
+    existingNodesToDecorate = info.existingNodesToDecorate;
+  }
+
+  return {
+    ...base,
+    literalArgs,
+    dependentKeys,
+    allLocal,
+    canAutoFix: true,
+    trackedDeps,
+    existingNodesToDecorate,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tracked dep deduplication
+// ---------------------------------------------------------------------------
+
+/**
+ * Ensure each new `@tracked` dep name is assigned to at most ONE usage.
+ * Without this, two macros referencing the same dep would both try to
+ * insert `@tracked propName;` (since new declarations are prepended to
+ * each property replacement to avoid range overlaps).
+ *
+ * Note: `existingNodesToDecorate` is NOT deduplicated here — those are
+ * aggregated centrally in the import-level fix via a Set.
+ *
+ * @param {MacroUsage[]} usages
+ */
+function deduplicateTrackedDeps(usages) {
+  const claimedDeps = new Set();
+
+  for (const usage of usages) {
+    if (usage.trackedDeps) {
+      usage.trackedDeps = usage.trackedDeps.filter((dep) => {
+        if (claimedDeps.has(dep)) {
+          return false;
+        }
+        claimedDeps.add(dep);
+        return true;
+      });
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// @tracked dependency detection
+// ---------------------------------------------------------------------------
+
+/**
+ * @typedef {Object} TrackedDepsInfo
+ * @property {string[]} depsToInsert - Deps that need a NEW `@tracked propName;` declaration
+ * @property {import('estree').Node[]} existingNodesToDecorate - Existing PropertyDefinition
+ *   nodes that need `@tracked` added as a decorator
+ */
+
+/**
+ * Given a PropertyDefinition inside a class body, determine which local
+ * dependent keys need `@tracked` handling:
+ *
+ * - Keys not declared as class members → need a new `@tracked propName;` inserted
+ * - Keys declared as members without `@tracked` → need `@tracked` added to the existing declaration
+ * - Keys already declared with `@tracked` → no action needed
+ *
+ * @param {import('estree').Node} propertyNode - The PropertyDefinition node
+ * @param {string[]} dependentKeys - Local-only dependent keys (no dots)
+ * @returns {TrackedDepsInfo}
+ */
+function findDepsNeedingTracked(propertyNode, dependentKeys) {
+  const classBody = propertyNode.parent;
+  if (!classBody || classBody.type !== "ClassBody") {
+    return { depsToInsert: [...dependentKeys], existingNodesToDecorate: [] };
+  }
+
+  const trackedMembers = new Set();
+  const untrackedMemberNodes = new Map(); // name → AST node
+
+  for (const member of classBody.body) {
+    if (member.type !== "PropertyDefinition") {
+      continue;
+    }
+
+    const name =
+      member.key.type === "Identifier"
+        ? member.key.name
+        : String(member.key.value);
+
+    const hasTracked =
+      member.decorators?.some((d) => {
+        const expr = d.expression;
+        return (
+          (expr.type === "Identifier" && expr.name === "tracked") ||
+          (expr.type === "CallExpression" &&
+            expr.callee?.type === "Identifier" &&
+            expr.callee.name === "tracked")
+        );
+      }) ?? false;
+
+    if (hasTracked) {
+      trackedMembers.add(name);
+    } else {
+      untrackedMemberNodes.set(name, member);
+    }
+  }
+
+  const depsToInsert = [];
+  const existingNodesToDecorate = [];
+
+  for (const key of dependentKeys) {
+    if (trackedMembers.has(key)) {
+      continue; // already tracked
+    }
+    if (untrackedMemberNodes.has(key)) {
+      existingNodesToDecorate.push(untrackedMemberNodes.get(key));
+    } else {
+      depsToInsert.push(key);
+    }
+  }
+
+  return { depsToInsert, existingNodesToDecorate };
+}
+
+// ---------------------------------------------------------------------------
+// AST walker
+// ---------------------------------------------------------------------------
+
+/**
+ * Simple recursive AST walker that calls `visitor(node)` for every node.
+ *
+ * @param {import('estree').Node} node
+ * @param {(node: import('estree').Node) => void} visitor
+ */
+function walkNode(node, visitor) {
+  if (!node || typeof node !== "object") {
+    return;
+  }
+
+  visitor(node);
+
+  for (const key in node) {
+    if (key === "parent" || key === "range" || key === "loc") {
+      continue;
+    }
+    const child = node[key];
+    if (Array.isArray(child)) {
+      for (const item of child) {
+        if (item && typeof item.type === "string") {
+          walkNode(item, visitor);
+        }
+      }
+    } else if (child && typeof child.type === "string") {
+      walkNode(child, visitor);
+    }
+  }
+}

--- a/lint-configs/eslint-rules/no-computed-macros/computed-macros-analysis.mjs
+++ b/lint-configs/eslint-rules/no-computed-macros/computed-macros-analysis.mjs
@@ -308,11 +308,18 @@ function buildUsage({
     };
   }
 
-  // Extract literal arguments; bail if any arg is non-literal when we need
-  // string args (all macros except match, which has a regex second arg)
+  // Extract literal arguments; bail if any dep-key arg is non-literal.
+  // Args beyond `depKeyArgCount` are "value args" — they can be non-literal
+  // (their source text is used verbatim in the getter body via sourceCode.getText).
   const literalArgs = [];
   for (let i = 0; i < argNodes.length; i++) {
     const argNode = argNodes[i];
+
+    // Value args (beyond dep key positions) don't need to be literals
+    if (transform.depKeyArgCount != null && i >= transform.depKeyArgCount) {
+      literalArgs.push(null);
+      continue;
+    }
 
     if (argNode.type === "Literal" && typeof argNode.value === "string") {
       literalArgs.push(argNode.value);

--- a/lint-configs/eslint-rules/no-computed-macros/computed-macros-analysis.mjs
+++ b/lint-configs/eslint-rules/no-computed-macros/computed-macros-analysis.mjs
@@ -2,11 +2,17 @@
  * @fileoverview Analysis helpers for the `no-computed-macros` ESLint rule.
  *
  * Performs read-only AST traversal to detect usages of computed property macros
- * from `@ember/object/computed` and `discourse/lib/computed`, determines whether
+ * from `@ember/object/computed`, `discourse/lib/computed`, and
+ * `discourse/lib/decorators`, determines whether
  * each usage can be auto-fixed, and collects the information the fixer needs.
  */
 
-import { isLocalKey, MACRO_TRANSFORMS } from "./macro-transforms.mjs";
+import {
+  isLocalKey,
+  MACRO_SOURCES,
+  MACRO_TRANSFORMS,
+  SOURCE_ALIASES,
+} from "./macro-transforms.mjs";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -89,7 +95,7 @@ export function analyzeMacroUsage(sourceCode, imports) {
 // ---------------------------------------------------------------------------
 
 /**
- * Scan the imports map for macro names from both target sources.
+ * Scan the imports map for macro names from all target sources.
  * Returns a map from local identifier name → canonical macro name.
  *
  * @param {Map<string, {node: import('estree').ImportDeclaration, specifiers: Array}>} imports
@@ -115,6 +121,25 @@ function collectMacroImports(imports) {
     }
   }
 
+  // Check alias sources (e.g. discourse/lib/decorators → @ember/object/computed)
+  for (const [aliasSource, canonicalSource] of SOURCE_ALIASES) {
+    const importInfo = imports.get(aliasSource);
+    if (!importInfo) {
+      continue;
+    }
+
+    for (const spec of importInfo.specifiers) {
+      if (spec.type !== "ImportSpecifier") {
+        continue;
+      }
+      const importedName = spec.imported.name;
+      const transform = MACRO_TRANSFORMS.get(importedName);
+      if (transform && transform.source === canonicalSource) {
+        result.set(spec.local.name, importedName);
+      }
+    }
+  }
+
   return result;
 }
 
@@ -127,7 +152,7 @@ function collectMacroImports(imports) {
 function collectMacroImportNodes(imports) {
   const result = new Map();
 
-  for (const source of ["@ember/object/computed", "discourse/lib/computed"]) {
+  for (const source of MACRO_SOURCES) {
     const importInfo = imports.get(source);
     if (importInfo) {
       result.set(source, importInfo.node);

--- a/lint-configs/eslint-rules/no-computed-macros/computed-macros-analysis.mjs
+++ b/lint-configs/eslint-rules/no-computed-macros/computed-macros-analysis.mjs
@@ -75,6 +75,7 @@ export function analyzeMacroUsage(sourceCode, imports) {
   //    another macro that uses @computed, it must also use @computed.
   // 3. Deduplicate so each new @tracked declaration is emitted by one fixer only.
   excludeDepsBeingConverted(usages);
+  excludeImplicitInjectionDeps(usages);
   forceComputedForClassicComponents(usages, imports);
   propagateComputedRequirement(usages);
   deduplicateTrackedDeps(usages);
@@ -368,6 +369,59 @@ function excludeDepsBeingConverted(usages) {
 }
 
 // ---------------------------------------------------------------------------
+// Implicit injection exclusion
+// ---------------------------------------------------------------------------
+
+// Property names implicitly injected into Ember framework classes by
+// Discourse's registerDiscourseImplicitInjections() (see
+// discourse/app/lib/implicit-injections.js). Adding @tracked for an
+// undeclared property with one of these names would shadow the inherited
+// injection with undefined.
+const IMPLICIT_INJECTION_NAMES = new Set([
+  // commonInjections (Controller, Component, Route, RestModel, RestAdapter)
+  "appEvents",
+  "pmTopicTrackingState",
+  "store",
+  "site",
+  "searchService",
+  "session",
+  "messageBus",
+  "siteSettings",
+  "topicTrackingState",
+  "keyValueStore",
+  // Controller, Component, Route extras
+  "capabilities",
+  "currentUser",
+]);
+
+/**
+ * Promote usages to `@computed` when any of their tracked deps (new
+ * declarations, not existing members) match a known implicitly-injected
+ * property name. Inserting `@tracked currentUser;` in a controller that
+ * inherits `currentUser` via implicit injection would shadow the injection
+ * with `undefined`.
+ *
+ * @param {MacroUsage[]} usages
+ */
+function excludeImplicitInjectionDeps(usages) {
+  for (const usage of usages) {
+    if (!usage.canAutoFix || !usage.allLocal || !usage.trackedDeps) {
+      continue;
+    }
+
+    const hasImplicitDep = usage.trackedDeps.some((dep) =>
+      IMPLICIT_INJECTION_NAMES.has(dep)
+    );
+
+    if (hasImplicitDep) {
+      usage.allLocal = false;
+      usage.trackedDeps = undefined;
+      usage.existingNodesToDecorate = undefined;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Classic component detection
 // ---------------------------------------------------------------------------
 
@@ -622,15 +676,6 @@ function deduplicateTrackedDeps(usages) {
 // @tracked dependency detection
 // ---------------------------------------------------------------------------
 
-// Decorators that make a property reactive (equivalent to @tracked).
-// Members with these decorators do not need @tracked added.
-const TRACKED_DECORATORS = new Set([
-  "tracked",
-  "trackedArray",
-  "dedupeTracked",
-  "resettableTracked",
-]);
-
 /**
  * @typedef {Object} TrackedDepsInfo
  * @property {string[]} depsToInsert - Deps that need a NEW `@tracked propName;` declaration
@@ -643,9 +688,9 @@ const TRACKED_DECORATORS = new Set([
  * dependent keys need `@tracked` handling:
  *
  * - Keys matching a MethodDefinition (getter/method) → already reactive, skip
- * - Keys declared as PropertyDefinition with a tracked-like decorator
- *   (@tracked, @trackedArray, @dedupeTracked, @resettableTracked) → skip
- * - Keys declared as PropertyDefinition without tracking → need `@tracked` added
+ * - Keys declared as PropertyDefinition with any decorator → already managed
+ *   by something (@service, @tracked, @inject, etc.), skip
+ * - Keys declared as PropertyDefinition without decorators → need `@tracked` added
  * - Keys not declared as any class member → need a new `@tracked propName;` inserted
  *
  * @param {import('estree').Node} propertyNode - The PropertyDefinition node
@@ -658,7 +703,7 @@ function findDepsNeedingTracked(propertyNode, dependentKeys) {
     return { depsToInsert: [...dependentKeys], existingNodesToDecorate: [] };
   }
 
-  const reactiveMembers = new Set(); // getters, methods, and tracked properties
+  const reactiveMembers = new Set(); // getters, methods, and decorated properties
   const untrackedMemberNodes = new Map(); // name → AST node
 
   for (const member of classBody.body) {
@@ -681,18 +726,9 @@ function findDepsNeedingTracked(propertyNode, dependentKeys) {
         ? member.key.name
         : String(member.key.value);
 
-    const hasTrackedLike =
-      member.decorators?.some((d) => {
-        const expr = d.expression;
-        return (
-          (expr.type === "Identifier" && TRACKED_DECORATORS.has(expr.name)) ||
-          (expr.type === "CallExpression" &&
-            expr.callee?.type === "Identifier" &&
-            TRACKED_DECORATORS.has(expr.callee.name))
-        );
-      }) ?? false;
-
-    if (hasTrackedLike) {
+    // Any decorated property is already managed by its decorator
+    // (@tracked, @service, @inject, etc.) — adding @tracked would be wrong.
+    if (member.decorators?.length > 0) {
       reactiveMembers.add(name);
     } else {
       untrackedMemberNodes.set(name, member);
@@ -704,7 +740,7 @@ function findDepsNeedingTracked(propertyNode, dependentKeys) {
 
   for (const key of dependentKeys) {
     if (reactiveMembers.has(key)) {
-      continue; // already reactive (getter, method, or @tracked)
+      continue; // already reactive (getter, method, or decorated property)
     }
     if (untrackedMemberNodes.has(key)) {
       existingNodesToDecorate.push(untrackedMemberNodes.get(key));

--- a/lint-configs/eslint-rules/no-computed-macros/computed-macros-analysis.mjs
+++ b/lint-configs/eslint-rules/no-computed-macros/computed-macros-analysis.mjs
@@ -77,6 +77,7 @@ export function analyzeMacroUsage(sourceCode, imports) {
   excludeDepsBeingConverted(usages);
   excludeImplicitInjectionDeps(usages);
   forceComputedForClassicComponents(usages, imports);
+  excludeUndeclaredDepsInSubclasses(usages, imports);
   propagateComputedRequirement(usages);
   deduplicateTrackedDeps(usages);
 
@@ -551,6 +552,96 @@ function forceComputedForClassicComponents(usages, importsMap) {
       usage.existingNodesToDecorate = undefined;
     }
   }
+}
+
+// ---------------------------------------------------------------------------
+// Undeclared dep exclusion for subclasses
+// ---------------------------------------------------------------------------
+
+/**
+ * Promote usages to `@computed` when a class extends an unknown (non-framework)
+ * superclass and the fixer would insert NEW `@tracked` declarations for deps
+ * not found in the current class body.
+ *
+ * Without cross-file analysis we cannot know whether an undeclared dep is
+ * genuinely new local state or an inherited property (computed getter,
+ * injection, etc.) from the parent class. Inserting `@tracked propName;`
+ * for an inherited property shadows it with `undefined`, breaking runtime
+ * behavior. Promoting to `@computed` uses Ember's string-based observation
+ * which works correctly through the prototype chain.
+ *
+ * Classes extending known Ember/Glimmer framework base classes (`@ember/*`,
+ * `@glimmer/*`, `ember-data/*`) are safe — their APIs are well-documented and
+ * the `IMPLICIT_INJECTION_NAMES` exclusion already handles their dangerous
+ * properties.
+ *
+ * Deps that ARE declared in the current class body (`existingNodesToDecorate`)
+ * are safe — the property is visibly local, so there is no shadowing risk.
+ *
+ * Must run after `forceComputedForClassicComponents` (so classic component
+ * usages already have `trackedDeps` cleared) and before
+ * `propagateComputedRequirement`.
+ *
+ * @param {MacroUsage[]} usages
+ * @param {Map<string, {node: import('estree').ImportDeclaration, specifiers: Array}>} importsMap
+ */
+function excludeUndeclaredDepsInSubclasses(usages, importsMap) {
+  for (const usage of usages) {
+    if (!usage.canAutoFix || !usage.allLocal || !usage.trackedDeps?.length) {
+      continue;
+    }
+
+    const classNode = usage.propertyNode.parent.parent;
+    if (!classNode.superClass) {
+      continue;
+    }
+
+    // Known Ember/Glimmer framework classes have well-documented APIs.
+    // IMPLICIT_INJECTION_NAMES already handles their dangerous properties.
+    if (isKnownFrameworkSuperclass(classNode, importsMap)) {
+      continue;
+    }
+
+    // Unknown superclass — could define computed getters or other
+    // properties we'd shadow. Promote to @computed for safety.
+    usage.allLocal = false;
+    usage.trackedDeps = undefined;
+    usage.existingNodesToDecorate = undefined;
+  }
+}
+
+/**
+ * Check whether a class's superclass is a default import from a known
+ * Ember/Glimmer framework package (`@ember/*`, `@glimmer/*`, `ember-data/*`).
+ *
+ * @param {import('estree').Node} classNode - ClassDeclaration or ClassExpression
+ * @param {Map<string, {node: import('estree').ImportDeclaration, specifiers: Array}>} importsMap
+ * @returns {boolean}
+ */
+function isKnownFrameworkSuperclass(classNode, importsMap) {
+  const superClass = classNode.superClass;
+  if (!superClass || superClass.type !== "Identifier") {
+    return false;
+  }
+
+  for (const [source, importInfo] of importsMap) {
+    if (
+      !source.startsWith("@ember/") &&
+      !source.startsWith("@glimmer/") &&
+      !source.startsWith("ember-data")
+    ) {
+      continue;
+    }
+
+    const defaultSpec = importInfo.specifiers.find(
+      (s) => s.type === "ImportDefaultSpecifier"
+    );
+    if (defaultSpec && defaultSpec.local.name === superClass.name) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 /**

--- a/lint-configs/eslint-rules/no-computed-macros/computed-macros-analysis.mjs
+++ b/lint-configs/eslint-rules/no-computed-macros/computed-macros-analysis.mjs
@@ -71,8 +71,12 @@ export function analyzeMacroUsage(sourceCode, imports) {
   // Post-process tracked deps:
   // 1. Remove deps that are themselves macro properties being converted to
   //    getters — adding @tracked to something that will become a getter is wrong.
-  // 2. Deduplicate so each new @tracked declaration is emitted by one fixer only.
+  // 2. Propagate @computed requirement transitively — if a macro depends on
+  //    another macro that uses @computed, it must also use @computed.
+  // 3. Deduplicate so each new @tracked declaration is emitted by one fixer only.
   excludeDepsBeingConverted(usages);
+  forceComputedForClassicComponents(usages, imports);
+  propagateComputedRequirement(usages);
   deduplicateTrackedDeps(usages);
 
   return { usages, importedMacros, macroImportNodes };
@@ -361,6 +365,230 @@ function excludeDepsBeingConverted(usages) {
       );
     }
   }
+}
+
+// ---------------------------------------------------------------------------
+// Classic component detection
+// ---------------------------------------------------------------------------
+
+// Decorators from @ember-decorators/component that are exclusively used on
+// classic Ember components (those extending @ember/component).
+const CLASSIC_COMPONENT_DECORATORS = new Set([
+  "classNames",
+  "classNameBindings",
+  "tagName",
+  "attributeBindings",
+]);
+
+/**
+ * Determine whether a class declaration represents a classic Ember component.
+ *
+ * Classic components use Ember's two-way binding system and cannot use
+ * `@tracked` + `@dependentKeyCompat` — they must use `@computed` instead.
+ *
+ * Detection signals:
+ * 1. Direct: superclass is `Component` imported from `@ember/component`
+ * 2. Decorator: class has decorators from `@ember-decorators/component`
+ * 3. Naming: superclass name ends with "Component" (and is NOT from `@glimmer/component`)
+ *
+ * @param {import('estree').Node} classNode - ClassDeclaration or ClassExpression
+ * @param {Map<string, {node: import('estree').ImportDeclaration, specifiers: Array}>} importsMap
+ * @returns {boolean}
+ */
+function isClassicComponent(classNode, importsMap) {
+  const superClass = classNode.superClass;
+  if (!superClass) {
+    return false;
+  }
+
+  // 1. Direct: extends Component from @ember/component
+  if (superClass.type === "Identifier") {
+    const componentImport = importsMap.get("@ember/component");
+    if (componentImport) {
+      const defaultSpec = componentImport.specifiers.find(
+        (s) => s.type === "ImportDefaultSpecifier"
+      );
+      if (defaultSpec && defaultSpec.local.name === superClass.name) {
+        return true;
+      }
+    }
+
+    // Explicit exclusion: @glimmer/component is NOT classic
+    const glimmerImport = importsMap.get("@glimmer/component");
+    if (glimmerImport) {
+      const defaultSpec = glimmerImport.specifiers.find(
+        (s) => s.type === "ImportDefaultSpecifier"
+      );
+      if (defaultSpec && defaultSpec.local.name === superClass.name) {
+        return false;
+      }
+    }
+  }
+
+  // 2. Decorator signal: @classNames, @tagName, etc. from @ember-decorators/component
+  if (classNode.decorators?.length > 0) {
+    const emberDecImport = importsMap.get("@ember-decorators/component");
+    if (emberDecImport) {
+      const importedNames = new Set(
+        emberDecImport.specifiers
+          .filter(
+            (s) =>
+              s.type === "ImportSpecifier" &&
+              CLASSIC_COMPONENT_DECORATORS.has(s.imported.name)
+          )
+          .map((s) => s.local.name)
+      );
+      const hasClassicDecorator = classNode.decorators.some((d) => {
+        const expr = d.expression;
+        const name =
+          expr.type === "Identifier"
+            ? expr.name
+            : expr.type === "CallExpression" &&
+                expr.callee?.type === "Identifier"
+              ? expr.callee.name
+              : null;
+        return name && importedNames.has(name);
+      });
+      if (hasClassicDecorator) {
+        return true;
+      }
+    }
+  }
+
+  // 3. Naming convention: superclass name ends with "Component"
+  const superName =
+    superClass.type === "Identifier"
+      ? superClass.name
+      : superClass.type === "MemberExpression"
+        ? superClass.property?.name
+        : null;
+  if (superName?.endsWith("Component")) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Force `@computed` (instead of `@dependentKeyCompat` + `@tracked`) for all
+ * fixable macros inside classic Ember components.
+ *
+ * Classic components rely on Ember's two-way binding system. Adding `@tracked`
+ * bypasses classic property notifications and breaks template bindings. Using
+ * `@computed` keeps everything within the classic property system.
+ *
+ * Must run before `propagateComputedRequirement` so that forced-computed macros
+ * seed the transitive propagation.
+ *
+ * @param {MacroUsage[]} usages
+ * @param {Map<string, {node: import('estree').ImportDeclaration, specifiers: Array}>} importsMap
+ */
+function forceComputedForClassicComponents(usages, importsMap) {
+  for (const usage of usages) {
+    if (!usage.canAutoFix || !usage.allLocal) {
+      continue;
+    }
+
+    const classBody = usage.propertyNode.parent;
+    const classNode = classBody.parent;
+    if (isClassicComponent(classNode, importsMap)) {
+      usage.allLocal = false;
+      usage.trackedDeps = undefined;
+      usage.existingNodesToDecorate = undefined;
+    }
+  }
+}
+
+/**
+ * Propagate the @computed requirement transitively through macro dependencies.
+ *
+ * A `@dependentKeyCompat` getter cannot observe a `@computed` getter.  So when
+ * a fixable macro depends on a `@computed` getter — either another macro being
+ * converted or an *existing* `@computed` getter already in the class — the macro
+ * must also use `@computed`.  This propagation is transitive.
+ *
+ * For each promoted macro we clear `trackedDeps` and `existingNodesToDecorate`
+ * because `@computed` getters don't require `@tracked` on their deps.
+ *
+ * @param {MacroUsage[]} usages
+ */
+function propagateComputedRequirement(usages) {
+  const classBuckets = new Map();
+  for (const usage of usages) {
+    if (!usage.canAutoFix) {
+      continue;
+    }
+    const classBody = usage.propertyNode.parent;
+    if (!classBuckets.has(classBody)) {
+      classBuckets.set(classBody, []);
+    }
+    classBuckets.get(classBody).push(usage);
+  }
+
+  for (const classUsages of classBuckets.values()) {
+    const classBody = classUsages[0].propertyNode.parent;
+
+    // Seed from macros being converted that already have nested deps
+    const computedPropNames = new Set();
+    for (const usage of classUsages) {
+      if (!usage.allLocal) {
+        computedPropNames.add(usage.propName);
+      }
+    }
+
+    // Seed from existing @computed getters already in the class
+    for (const member of classBody.body) {
+      if (member.type === "MethodDefinition" && hasComputedDecorator(member)) {
+        const name =
+          member.key.type === "Identifier"
+            ? member.key.name
+            : String(member.key.value);
+        computedPropNames.add(name);
+      }
+    }
+
+    if (computedPropNames.size === 0) {
+      continue;
+    }
+
+    // Fixed-point loop: keep propagating until no new promotions occur
+    let changed = true;
+    while (changed) {
+      changed = false;
+      for (const usage of classUsages) {
+        if (!usage.allLocal) {
+          continue;
+        }
+        if (usage.dependentKeys.some((k) => computedPropNames.has(k))) {
+          usage.allLocal = false;
+          usage.trackedDeps = undefined;
+          usage.existingNodesToDecorate = undefined;
+          computedPropNames.add(usage.propName);
+          changed = true;
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Check whether a class member has a `@computed` decorator.
+ *
+ * @param {import('estree').Node} member
+ * @returns {boolean}
+ */
+function hasComputedDecorator(member) {
+  return (
+    member.decorators?.some((d) => {
+      const expr = d.expression;
+      return (
+        (expr.type === "Identifier" && expr.name === "computed") ||
+        (expr.type === "CallExpression" &&
+          expr.callee?.type === "Identifier" &&
+          expr.callee.name === "computed")
+      );
+    }) ?? false
+  );
 }
 
 /**

--- a/lint-configs/eslint-rules/no-computed-macros/computed-macros-fixer.mjs
+++ b/lint-configs/eslint-rules/no-computed-macros/computed-macros-fixer.mjs
@@ -1,0 +1,174 @@
+/**
+ * @fileoverview Fixer logic for the `no-computed-macros` ESLint rule.
+ *
+ * Generates ESLint fixer functions that replace a macro-decorated
+ * PropertyDefinition with a native getter, adjusting decorators.
+ * New `@tracked` declarations for local deps are prepended to the replacement
+ * text (rather than using a separate insertTextBefore) to avoid range overlaps.
+ * Decorating *existing* class members with `@tracked` is handled centrally in
+ * the import-level fix (see `no-computed-macros.mjs`) to avoid duplication.
+ */
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a fixer function for a single macro usage.
+ *
+ * The returned function replaces the PropertyDefinition (including its
+ * decorators) with an optional block of `@tracked` declarations followed
+ * by a `@computed(...)` or `@dependentKeyCompat` getter.
+ *
+ * Note: decorating *existing* class members with `@tracked` is NOT handled
+ * here — it's aggregated in the import-level fix to avoid duplication.
+ *
+ * @param {import('./computed-macros-analysis.mjs').MacroUsage} usage
+ * @param {import('eslint').SourceCode} sourceCode
+ * @returns {(fixer: import('eslint').Rule.RuleFixer) => import('eslint').Rule.Fix}
+ */
+export function createMacroFix(usage, sourceCode) {
+  return function (fixer) {
+    const indent = detectIndent(usage.propertyNode, sourceCode);
+    const getterCode = buildGetterCode(usage, indent, sourceCode);
+
+    // Prepend @tracked declarations for local deps that need a NEW member
+    let trackedPrefix = "";
+    if (usage.allLocal && usage.trackedDeps?.length > 0) {
+      trackedPrefix = buildTrackedPrefix(usage, indent);
+    }
+
+    const start = getNodeStart(usage, sourceCode);
+    const end = getNodeEnd(usage.propertyNode, sourceCode);
+    return fixer.replaceTextRange([start, end], trackedPrefix + getterCode);
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Getter code generation
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the full getter code string including decorator.
+ *
+ * @param {import('./computed-macros-analysis.mjs').MacroUsage} usage
+ * @param {string} indent
+ * @param {import('eslint').SourceCode} sourceCode
+ * @returns {string}
+ */
+function buildGetterCode(usage, indent, sourceCode) {
+  const {
+    transform,
+    propName,
+    allLocal,
+    dependentKeys,
+    literalArgs,
+    argNodes,
+  } = usage;
+  const transformArgs = { literalArgs, argNodes, propName, sourceCode };
+  const bodyRaw = transform.toGetterBody(transformArgs);
+
+  // Build decorator line
+  let decoratorLine;
+  if (allLocal) {
+    decoratorLine = `${indent}@dependentKeyCompat`;
+  } else {
+    const keys = dependentKeys.map((k) => JSON.stringify(k)).join(", ");
+    decoratorLine = `${indent}@computed(${keys})`;
+  }
+
+  // Build getter body — handle multi-line bodies (e.g. sort)
+  const bodyLines = bodyRaw.split("\n");
+  const bodyIndent = `${indent}  `;
+  const formattedBody = bodyLines
+    .map((line) => `${bodyIndent}${line}`)
+    .join("\n");
+
+  return [
+    decoratorLine,
+    `${indent}get ${propName}() {`,
+    formattedBody,
+    `${indent}}`,
+  ].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// @tracked prefix
+// ---------------------------------------------------------------------------
+
+/**
+ * Build `@tracked propName;` declarations to prepend before the getter.
+ * `trackedDeps` already contains only deps that need a NEW declaration
+ * (not existing class members — those are handled separately via
+ * `existingNodesToDecorate`).
+ *
+ * @param {import('./computed-macros-analysis.mjs').MacroUsage} usage
+ * @param {string} indent
+ * @returns {string}
+ */
+function buildTrackedPrefix(usage, indent) {
+  return usage.trackedDeps.map((dep) => `${indent}@tracked ${dep};\n`).join("");
+}
+
+// ---------------------------------------------------------------------------
+// Node range helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Get the start position of a usage, including its decorators AND any
+ * leading whitespace on the same line. This ensures the replacement range
+ * covers the full indentation so the generated code can control its own
+ * indentation without doubling.
+ */
+function getNodeStart(usage, sourceCode) {
+  const { propertyNode } = usage;
+  const text = sourceCode.getText();
+  let pos =
+    propertyNode.decorators?.length > 0
+      ? propertyNode.decorators[0].range[0]
+      : propertyNode.range[0];
+
+  // Walk back to the start of the line (past whitespace)
+  while (pos > 0 && text[pos - 1] !== "\n") {
+    pos--;
+  }
+
+  return pos;
+}
+
+/**
+ * Get the end position of a PropertyDefinition, consuming trailing semicolons.
+ */
+function getNodeEnd(node, sourceCode) {
+  let end = node.range[1];
+  const text = sourceCode.getText();
+  while (end < text.length && text[end] === ";") {
+    end++;
+  }
+  return end;
+}
+
+// ---------------------------------------------------------------------------
+// Indentation helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect the indentation of a node by looking at leading whitespace.
+ */
+function detectIndent(node, sourceCode) {
+  const text = sourceCode.getText();
+  let pos =
+    node.decorators?.length > 0 ? node.decorators[0].range[0] : node.range[0];
+
+  while (pos > 0 && text[pos - 1] !== "\n") {
+    pos--;
+  }
+
+  let indent = "";
+  while (pos < text.length && (text[pos] === " " || text[pos] === "\t")) {
+    indent += text[pos];
+    pos++;
+  }
+
+  return indent;
+}

--- a/lint-configs/eslint-rules/no-computed-macros/computed-macros-fixer.mjs
+++ b/lint-configs/eslint-rules/no-computed-macros/computed-macros-fixer.mjs
@@ -203,12 +203,31 @@ function buildGetterCode(usage, indent, sourceCode) {
     .map((line) => `${bodyIndent}${line}`)
     .join("\n");
 
-  return [
+  const parts = [
     decoratorLine,
     `${indent}get ${propName}() {`,
     formattedBody,
     `${indent}}`,
-  ].join("\n");
+  ];
+
+  // Append setter for bidirectional macros (e.g. alias)
+  if (transform.toSetterBody) {
+    const setterBody = transform.toSetterBody({
+      ...transformArgs,
+      useEmberSet: !allLocal,
+    });
+    const setterLines = setterBody.split("\n");
+    const formattedSetterBody = setterLines
+      .map((line) => `${bodyIndent}${line}`)
+      .join("\n");
+    parts.push(
+      `${indent}set ${propName}(value) {`,
+      formattedSetterBody,
+      `${indent}}`
+    );
+  }
+
+  return parts.join("\n");
 }
 
 // ---------------------------------------------------------------------------

--- a/lint-configs/eslint-rules/no-computed-macros/computed-macros-fixer.mjs
+++ b/lint-configs/eslint-rules/no-computed-macros/computed-macros-fixer.mjs
@@ -3,8 +3,10 @@
  *
  * Generates a combined ESLint fixer function per class that:
  * 1. Removes each macro PropertyDefinition
- * 2. Collects all @tracked declarations (new + moved) and inserts them
- *    at the [tracked-properties] section
+ * 2. Collects @tracked declarations and inserts them at the correct
+ *    sort-class-members section:
+ *    - Regular tracked → [tracked-properties]
+ *    - Override fields (e.g. oneWay `_propOverride`) → [private-properties]
  * 3. Inserts all generated getters at the correct class body position
  *    (the [everything-else] section, after all property-like members)
  *
@@ -71,16 +73,31 @@ export function createClassFix(
       fixes.push(fixer.replaceTextRange([start, end], ""));
     }
 
-    // ---- 2. Collect @tracked declarations and insert at tracked section ----
-    // Both new declarations (from trackedDeps) and moved existing members
-    // (from existingNodesToDecorate) are placed together in the
-    // [tracked-properties] section for correct sort-class-members order.
+    // ---- 2. Collect @tracked declarations ----
+    // Regular tracked (from trackedDeps / existingNodesToDecorate) go to
+    // [tracked-properties]; override fields (from overrideTrackedFields,
+    // e.g. oneWay's `_propOverride`) go to [private-properties] because
+    // their `_` prefix matches the sort-class-members private pattern.
     const trackedLines = [];
+    const privateTrackedLines = [];
     const seenTrackedDeps = new Set();
     const processedNodes = new Set();
 
     for (const usage of classUsages) {
-      // New @tracked declarations from trackedDeps
+      // Override tracked fields → [private-properties] section
+      if (usage.transform.overrideTrackedFields) {
+        for (const field of usage.transform.overrideTrackedFields({
+          propName: usage.propName,
+        })) {
+          const line =
+            field.initializer != null
+              ? `${indent}@tracked ${field.name} = ${field.initializer};\n`
+              : `${indent}@tracked ${field.name};\n`;
+          privateTrackedLines.push(line);
+        }
+      }
+
+      // New @tracked declarations from trackedDeps → [tracked-properties]
       if (usage.allLocal && usage.trackedDeps?.length > 0) {
         for (const dep of usage.trackedDeps) {
           if (!seenTrackedDeps.has(dep)) {
@@ -90,7 +107,7 @@ export function createClassFix(
         }
       }
 
-      // Move existing members with @tracked prepended
+      // Move existing members with @tracked prepended → [tracked-properties]
       if (usage.existingNodesToDecorate) {
         for (const memberNode of usage.existingNodesToDecorate) {
           if (processedNodes.has(memberNode)) {
@@ -117,19 +134,71 @@ export function createClassFix(
       }
     }
 
-    if (trackedLines.length > 0) {
-      const trackedInsertPos = findTrackedInsertionPoint(
-        classBody,
-        macroNodeSet,
-        existingNodesToDecorate,
-        text
-      );
+    // Compute insertion positions
+    const trackedInsertPos =
+      trackedLines.length > 0
+        ? findTrackedInsertionPoint(
+            classBody,
+            macroNodeSet,
+            existingNodesToDecorate,
+            text
+          )
+        : null;
+
+    const privateInsertPos =
+      privateTrackedLines.length > 0
+        ? findPrivatePropertyInsertionPoint(
+            classBody,
+            macroNodeSet,
+            existingNodesToDecorate,
+            text
+          )
+        : null;
+
+    // ESLint rejects overlapping fixes at the same position, so when both
+    // insertions target the same point (e.g. class with only macro members),
+    // combine them into a single insertion: tracked first, then private.
+    if (
+      trackedInsertPos !== null &&
+      privateInsertPos !== null &&
+      trackedInsertPos === privateInsertPos
+    ) {
       fixes.push(
         fixer.insertTextBeforeRange(
           [trackedInsertPos, trackedInsertPos],
-          trackedLines.join("")
+          trackedLines.join("") + "\n" + privateTrackedLines.join("")
         )
       );
+    } else {
+      if (trackedInsertPos !== null) {
+        fixes.push(
+          fixer.insertTextBeforeRange(
+            [trackedInsertPos, trackedInsertPos],
+            trackedLines.join("")
+          )
+        );
+      }
+
+      // Insert override fields at [private-properties] section (after all
+      // other PropertyDefinitions, before methods/getters).
+      if (privateInsertPos !== null) {
+        // Blank line separator before the private section when there are
+        // other property-like members above
+        const hasPropertiesAbove = classBody.body.some(
+          (m) =>
+            !macroNodeSet.has(m) &&
+            !existingNodesToDecorate.has(m) &&
+            m.type === "PropertyDefinition" &&
+            m.range[1] <= privateInsertPos
+        );
+        const privatePrefix = hasPropertiesAbove ? "\n" : "";
+        fixes.push(
+          fixer.insertTextBeforeRange(
+            [privateInsertPos, privateInsertPos],
+            privatePrefix + privateTrackedLines.join("")
+          )
+        );
+      }
     }
 
     // ---- 3. Insert all getters at the correct position ----
@@ -349,6 +418,59 @@ function findTrackedInsertionPoint(
 }
 
 /**
+ * Find the position to insert override tracked fields (e.g. oneWay's
+ * `_propOverride`). These use a `_` prefix, so sort-class-members classifies
+ * them as [private-properties], which comes after [properties] and before
+ * lifecycle methods / [everything-else].
+ *
+ * Strategy: insert after the last non-macro, non-moved PropertyDefinition.
+ * This places private tracked fields after all other property-like members.
+ *
+ * @param {import('estree').ClassBody} classBody
+ * @param {Set<import('estree').Node>} macroNodeSet
+ * @param {Set<import('estree').Node>} existingNodesToDecorate
+ * @param {string} text
+ * @returns {number}
+ */
+function findPrivatePropertyInsertionPoint(
+  classBody,
+  macroNodeSet,
+  existingNodesToDecorate,
+  text
+) {
+  let lastPropertyEnd = null;
+
+  for (const member of classBody.body) {
+    if (macroNodeSet.has(member) || existingNodesToDecorate.has(member)) {
+      continue;
+    }
+    if (member.type !== "PropertyDefinition") {
+      continue;
+    }
+
+    let pos = member.range[1];
+    while (pos < text.length && text[pos] === ";") {
+      pos++;
+    }
+    if (pos < text.length && text[pos] === "\n") {
+      pos++;
+    }
+    lastPropertyEnd = pos;
+  }
+
+  if (lastPropertyEnd !== null) {
+    return lastPropertyEnd;
+  }
+
+  // No properties found — insert at start of class body
+  let pos = classBody.range[0] + 1;
+  if (pos < text.length && text[pos] === "\n") {
+    pos++;
+  }
+  return pos;
+}
+
+/**
  * Check whether a class member has a tracked-like decorator.
  *
  * @param {import('estree').Node} member
@@ -404,10 +526,12 @@ function hasContentBeforeInsertion(
 ) {
   // True if any macro produces @tracked declarations (placed at the
   // tracked section, which is always before the getter insertion point)
-  const hasTrackedDeps = classUsages.some(
-    (u) => u.allLocal && u.trackedDeps?.length > 0
+  const hasTrackedContent = classUsages.some(
+    (u) =>
+      (u.allLocal && u.trackedDeps?.length > 0) ||
+      u.transform.overrideTrackedFields
   );
-  if (hasTrackedDeps) {
+  if (hasTrackedContent) {
     return true;
   }
   // True if any existing members are being moved (they get re-inserted

--- a/lint-configs/eslint-rules/no-computed-macros/macro-transforms.mjs
+++ b/lint-configs/eslint-rules/no-computed-macros/macro-transforms.mjs
@@ -1,0 +1,602 @@
+/**
+ * @fileoverview Transform registry for computed property macros.
+ *
+ * Maps each macro name to its source, whether it can be auto-fixed,
+ * what additional imports the transformation requires, how to generate
+ * the getter body, and how to derive the dependent keys for @computed.
+ */
+
+import { propertyPathToOptionalChaining } from "../utils/property-path.mjs";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a property-path string to a `this.`-prefixed accessor.
+ * Delegates to the shared utility from `utils/property-path.mjs`.
+ *
+ * @param {string} path
+ * @returns {string}
+ */
+function toAccess(path) {
+  return propertyPathToOptionalChaining(path, true, false);
+}
+
+/**
+ * Render a JS literal value suitable for source output.
+ * Strings → quoted, numbers/booleans → as-is, null → "null".
+ *
+ * @param {*} value
+ * @returns {string}
+ */
+function renderLiteral(value) {
+  if (typeof value === "string") {
+    return JSON.stringify(value);
+  }
+  return String(value);
+}
+
+/**
+ * Parse an Ember-style format string (using `%@` / `%@N` placeholders)
+ * and return a JS template-literal expression.
+ *
+ * @param {string} format  - the format string, e.g. "/admin/users/%@1/%@2"
+ * @param {string[]} propPaths - the property-path arguments preceding the format string
+ * @returns {string} a template literal expression (with backticks)
+ */
+function fmtToTemplateLiteral(format, propPaths) {
+  let seqIdx = 0;
+  const result = format.replace(/%@(\d+)?/g, (_match, indexStr) => {
+    const idx = indexStr ? parseInt(indexStr, 10) - 1 : seqIdx++;
+    const path = propPaths[idx];
+    if (!path) {
+      return "";
+    }
+    return `\${${toAccess(path)}}`;
+  });
+  return `\`${result}\``;
+}
+
+/**
+ * Check whether a dependent-key string is "local" (no dots, no special
+ * tokens like `@each` or `[]`).
+ *
+ * @param {string} key
+ * @returns {boolean}
+ */
+export function isLocalKey(key) {
+  return !key.includes(".");
+}
+
+// ---------------------------------------------------------------------------
+// Individual transforms
+// ---------------------------------------------------------------------------
+
+/** @typedef {{ name: string, source: string, isDefault?: boolean }} RequiredImport */
+
+/**
+ * @typedef {Object} MacroTransform
+ * @property {string} source - import source where the macro lives
+ * @property {boolean} canAutoFix
+ * @property {string} [reason] - explanation when canAutoFix is false
+ * @property {RequiredImport[]} [requiredImports]
+ * @property {(args: TransformArgs) => string} [toGetterBody]
+ * @property {(args: TransformArgs) => string[]} [toDependentKeys]
+ */
+
+/**
+ * @typedef {Object} TransformArgs
+ * @property {string[]} literalArgs - the literal string/number values of the decorator arguments
+ * @property {import('estree').Node[]} argNodes - raw AST argument nodes
+ * @property {string} propName - the decorated property name
+ * @property {import('eslint').SourceCode} sourceCode
+ */
+
+const EMBER_SOURCE = "@ember/object/computed";
+const DISCOURSE_SOURCE = "discourse/lib/computed";
+
+// ---- @ember/object/computed ------------------------------------------------
+
+const simpleAccess = {
+  source: EMBER_SOURCE,
+  canAutoFix: true,
+  toGetterBody({ literalArgs: [path] }) {
+    return `return ${toAccess(path)};`;
+  },
+  toDependentKeys({ literalArgs: [path] }) {
+    return [path];
+  },
+};
+
+const alias = { ...simpleAccess };
+const readOnly = { ...simpleAccess };
+const reads = { ...simpleAccess };
+const oneWay = { ...simpleAccess };
+
+const not = {
+  source: EMBER_SOURCE,
+  canAutoFix: true,
+  toGetterBody({ literalArgs: [path] }) {
+    return `return !${toAccess(path)};`;
+  },
+  toDependentKeys({ literalArgs: [path] }) {
+    return [path];
+  },
+};
+
+const bool = {
+  source: EMBER_SOURCE,
+  canAutoFix: true,
+  toGetterBody({ literalArgs: [path] }) {
+    return `return !!${toAccess(path)};`;
+  },
+  toDependentKeys({ literalArgs: [path] }) {
+    return [path];
+  },
+};
+
+const and = {
+  source: EMBER_SOURCE,
+  canAutoFix: true,
+  toGetterBody({ literalArgs }) {
+    return `return ${literalArgs.map(toAccess).join(" && ")};`;
+  },
+  toDependentKeys({ literalArgs }) {
+    return [...literalArgs];
+  },
+};
+
+const or = {
+  source: EMBER_SOURCE,
+  canAutoFix: true,
+  toGetterBody({ literalArgs }) {
+    return `return ${literalArgs.map(toAccess).join(" || ")};`;
+  },
+  toDependentKeys({ literalArgs }) {
+    return [...literalArgs];
+  },
+};
+
+function comparisonMacro(operator) {
+  return {
+    source: EMBER_SOURCE,
+    canAutoFix: true,
+    toGetterBody({ literalArgs: [path], argNodes }) {
+      const valueText =
+        argNodes[1] && argNodes[1].raw !== undefined
+          ? argNodes[1].raw
+          : renderLiteral(argNodes[1] && argNodes[1].value);
+      return `return ${toAccess(path)} ${operator} ${valueText};`;
+    },
+    toDependentKeys({ literalArgs: [path] }) {
+      return [path];
+    },
+  };
+}
+
+const equal = comparisonMacro("===");
+const gt = comparisonMacro(">");
+const gte = comparisonMacro(">=");
+const lt = comparisonMacro("<");
+const lte = comparisonMacro("<=");
+
+const notEmpty = {
+  source: EMBER_SOURCE,
+  canAutoFix: true,
+  requiredImports: [{ name: "isEmpty", source: "@ember/utils" }],
+  toGetterBody({ literalArgs: [path] }) {
+    return `return !isEmpty(${toAccess(path)});`;
+  },
+  toDependentKeys({ literalArgs: [path] }) {
+    return [`${path}.length`];
+  },
+};
+
+const empty = {
+  source: EMBER_SOURCE,
+  canAutoFix: true,
+  requiredImports: [{ name: "isEmpty", source: "@ember/utils" }],
+  toGetterBody({ literalArgs: [path] }) {
+    return `return isEmpty(${toAccess(path)});`;
+  },
+  toDependentKeys({ literalArgs: [path] }) {
+    return [`${path}.length`];
+  },
+};
+
+const none = {
+  source: EMBER_SOURCE,
+  canAutoFix: true,
+  toGetterBody({ literalArgs: [path] }) {
+    return `return ${toAccess(path)} == null;`;
+  },
+  toDependentKeys({ literalArgs: [path] }) {
+    return [path];
+  },
+};
+
+const match = {
+  source: EMBER_SOURCE,
+  canAutoFix: true,
+  toGetterBody({ literalArgs: [path], argNodes, sourceCode }) {
+    const regexText = sourceCode.getText(argNodes[1]);
+    return `return ${regexText}.test(${toAccess(path)});`;
+  },
+  toDependentKeys({ literalArgs: [path] }) {
+    return [path];
+  },
+};
+
+const mapBy = {
+  source: EMBER_SOURCE,
+  canAutoFix: true,
+  toGetterBody({ literalArgs: [arrPath, prop] }) {
+    return `return ${toAccess(arrPath)}?.map((item) => item.${prop}) ?? [];`;
+  },
+  toDependentKeys({ literalArgs: [arrPath, prop] }) {
+    return [`${arrPath}.@each.${prop}`];
+  },
+};
+
+const filterBy = {
+  source: EMBER_SOURCE,
+  canAutoFix: true,
+  toGetterBody({ literalArgs, argNodes }) {
+    const arrPath = literalArgs[0];
+    const prop = literalArgs[1];
+    if (argNodes.length === 3) {
+      const valueText =
+        argNodes[2].raw !== undefined
+          ? argNodes[2].raw
+          : renderLiteral(argNodes[2].value);
+      return `return ${toAccess(arrPath)}?.filter((item) => item.${prop} === ${valueText}) ?? [];`;
+    }
+    return `return ${toAccess(arrPath)}?.filter((item) => item.${prop}) ?? [];`;
+  },
+  toDependentKeys({ literalArgs: [arrPath, prop] }) {
+    return [`${arrPath}.@each.${prop}`];
+  },
+};
+
+const collect = {
+  source: EMBER_SOURCE,
+  canAutoFix: true,
+  toGetterBody({ literalArgs }) {
+    const items = literalArgs
+      .map((p) => {
+        const access = toAccess(p);
+        return `${access} === undefined ? null : ${access}`;
+      })
+      .join(", ");
+    return `return [${items}];`;
+  },
+  toDependentKeys({ literalArgs }) {
+    return [...literalArgs];
+  },
+};
+
+const sum = {
+  source: EMBER_SOURCE,
+  canAutoFix: true,
+  toGetterBody({ literalArgs: [path] }) {
+    return `return ${toAccess(path)}?.reduce((s, v) => s + v, 0) ?? 0;`;
+  },
+  toDependentKeys({ literalArgs: [path] }) {
+    return [`${path}.[]`];
+  },
+};
+
+const max = {
+  source: EMBER_SOURCE,
+  canAutoFix: true,
+  toGetterBody({ literalArgs: [path] }) {
+    return `return ${toAccess(path)}?.reduce((m, v) => Math.max(m, v), -Infinity) ?? -Infinity;`;
+  },
+  toDependentKeys({ literalArgs: [path] }) {
+    return [`${path}.[]`];
+  },
+};
+
+const min = {
+  source: EMBER_SOURCE,
+  canAutoFix: true,
+  toGetterBody({ literalArgs: [path] }) {
+    return `return ${toAccess(path)}?.reduce((m, v) => Math.min(m, v), Infinity) ?? Infinity;`;
+  },
+  toDependentKeys({ literalArgs: [path] }) {
+    return [`${path}.[]`];
+  },
+};
+
+const uniq = {
+  source: EMBER_SOURCE,
+  canAutoFix: true,
+  requiredImports: [
+    { name: "uniqueItemsFromArray", source: "discourse/lib/array-tools" },
+  ],
+  toGetterBody({ literalArgs }) {
+    if (literalArgs.length === 1) {
+      return `return uniqueItemsFromArray(${toAccess(literalArgs[0])} ?? []);`;
+    }
+    const spreads = literalArgs
+      .map((p) => `...(${toAccess(p)} ?? [])`)
+      .join(", ");
+    return `return uniqueItemsFromArray([${spreads}]);`;
+  },
+  toDependentKeys({ literalArgs }) {
+    return literalArgs.map((p) => `${p}.[]`);
+  },
+};
+
+const uniqBy = {
+  source: EMBER_SOURCE,
+  canAutoFix: true,
+  requiredImports: [
+    { name: "uniqueItemsFromArray", source: "discourse/lib/array-tools" },
+  ],
+  toGetterBody({ literalArgs: [arrPath, key] }) {
+    return `return uniqueItemsFromArray(${toAccess(arrPath)} ?? [], ${renderLiteral(key)});`;
+  },
+  toDependentKeys({ literalArgs: [arrPath] }) {
+    return [`${arrPath}.[]`];
+  },
+};
+
+// union === uniq (same function in Ember)
+const union = { ...uniq };
+
+const intersect = {
+  source: EMBER_SOURCE,
+  canAutoFix: true,
+  toGetterBody({ literalArgs }) {
+    // Ember filters from the LAST array against all others
+    const last = literalArgs[literalArgs.length - 1];
+    const rest = literalArgs.slice(0, -1);
+    const conditions = rest
+      .map((p) => `(${toAccess(p)} ?? []).includes(item)`)
+      .join(" && ");
+    return `return (${toAccess(last)} ?? []).filter((item) => ${conditions});`;
+  },
+  toDependentKeys({ literalArgs }) {
+    return literalArgs.map((p) => `${p}.[]`);
+  },
+};
+
+const setDiff = {
+  source: EMBER_SOURCE,
+  canAutoFix: true,
+  toGetterBody({ literalArgs: [a, b] }) {
+    return `return (${toAccess(a)} ?? []).filter((item) => !(${toAccess(b)} ?? []).includes(item));`;
+  },
+  toDependentKeys({ literalArgs: [a, b] }) {
+    return [`${a}.[]`, `${b}.[]`];
+  },
+};
+
+const sort = {
+  source: EMBER_SOURCE,
+  canAutoFix: true,
+  requiredImports: [{ name: "compare", source: "@ember/utils" }],
+  toGetterBody({ literalArgs: [arrPath, sortDefPath] }) {
+    return [
+      `return [...(${toAccess(arrPath)} ?? [])].sort((a, b) => {`,
+      `  for (const s of ${toAccess(sortDefPath)} ?? []) {`,
+      `    const [prop, dir = "asc"] = s.split(":");`,
+      `    const result = compare(a[prop], b[prop]);`,
+      `    if (result !== 0) {`,
+      `      return dir === "desc" ? -result : result;`,
+      `    }`,
+      `  }`,
+      `  return 0;`,
+      `});`,
+    ].join("\n");
+  },
+  toDependentKeys({ literalArgs: [arrPath, sortDefPath] }) {
+    return [`${arrPath}.[]`, `${sortDefPath}.[]`];
+  },
+};
+
+// filter/map with callback — not auto-fixable
+const filter = {
+  source: EMBER_SOURCE,
+  canAutoFix: false,
+  reason: "callback-based macro requires manual conversion",
+};
+
+const map = {
+  source: EMBER_SOURCE,
+  canAutoFix: false,
+  reason: "callback-based macro requires manual conversion",
+};
+
+// ---- discourse/lib/computed ------------------------------------------------
+
+const propertyEqual = {
+  source: DISCOURSE_SOURCE,
+  canAutoFix: true,
+  requiredImports: [{ name: "deepEqual", source: "discourse/lib/object" }],
+  toGetterBody({ literalArgs: [a, b] }) {
+    return `return deepEqual(${toAccess(a)}, ${toAccess(b)});`;
+  },
+  toDependentKeys({ literalArgs: [a, b] }) {
+    return [a, b];
+  },
+};
+
+const propertyNotEqual = {
+  source: DISCOURSE_SOURCE,
+  canAutoFix: true,
+  requiredImports: [{ name: "deepEqual", source: "discourse/lib/object" }],
+  toGetterBody({ literalArgs: [a, b] }) {
+    return `return !deepEqual(${toAccess(a)}, ${toAccess(b)});`;
+  },
+  toDependentKeys({ literalArgs: [a, b] }) {
+    return [a, b];
+  },
+};
+
+const propertyGreaterThan = {
+  source: DISCOURSE_SOURCE,
+  canAutoFix: true,
+  toGetterBody({ literalArgs: [a, b] }) {
+    return `return ${toAccess(a)} > ${toAccess(b)};`;
+  },
+  toDependentKeys({ literalArgs: [a, b] }) {
+    return [a, b];
+  },
+};
+
+const propertyLessThan = {
+  source: DISCOURSE_SOURCE,
+  canAutoFix: true,
+  toGetterBody({ literalArgs: [a, b] }) {
+    return `return ${toAccess(a)} < ${toAccess(b)};`;
+  },
+  toDependentKeys({ literalArgs: [a, b] }) {
+    return [a, b];
+  },
+};
+
+const setting = {
+  source: DISCOURSE_SOURCE,
+  canAutoFix: true,
+  toGetterBody({ literalArgs: [name] }) {
+    return `return this.siteSettings.${name};`;
+  },
+  toDependentKeys({ literalArgs: [name] }) {
+    return [`siteSettings.${name}`];
+  },
+};
+
+const fmt = {
+  source: DISCOURSE_SOURCE,
+  canAutoFix: true,
+  toGetterBody({ literalArgs }) {
+    const format = literalArgs[literalArgs.length - 1];
+    const propPaths = literalArgs.slice(0, -1);
+    return `return ${fmtToTemplateLiteral(format, propPaths)};`;
+  },
+  toDependentKeys({ literalArgs }) {
+    return literalArgs.slice(0, -1);
+  },
+};
+
+const url = {
+  source: DISCOURSE_SOURCE,
+  canAutoFix: true,
+  requiredImports: [
+    { name: "getURL", source: "discourse/lib/get-url", isDefault: true },
+  ],
+  toGetterBody({ literalArgs }) {
+    const format = literalArgs[literalArgs.length - 1];
+    const propPaths = literalArgs.slice(0, -1);
+    return `return getURL(${fmtToTemplateLiteral(format, propPaths)});`;
+  },
+  toDependentKeys({ literalArgs }) {
+    return literalArgs.slice(0, -1);
+  },
+};
+
+const i18n = {
+  source: DISCOURSE_SOURCE,
+  canAutoFix: true,
+  requiredImports: [{ name: "i18n", source: "discourse-i18n" }],
+  toGetterBody({ literalArgs }) {
+    const format = literalArgs[literalArgs.length - 1];
+    const propPaths = literalArgs.slice(0, -1);
+    return `return i18n(${fmtToTemplateLiteral(format, propPaths)});`;
+  },
+  toDependentKeys({ literalArgs }) {
+    return literalArgs.slice(0, -1);
+  },
+};
+
+const htmlSafe = {
+  source: DISCOURSE_SOURCE,
+  canAutoFix: true,
+  requiredImports: [{ name: "htmlSafe", source: "@ember/template" }],
+  toGetterBody({ literalArgs: [path] }) {
+    return `return htmlSafe(${toAccess(path)});`;
+  },
+  toDependentKeys({ literalArgs: [path] }) {
+    return [path];
+  },
+};
+
+const endWith = {
+  source: DISCOURSE_SOURCE,
+  canAutoFix: true,
+  toGetterBody({ literalArgs }) {
+    const suffix = literalArgs[literalArgs.length - 1];
+    const propPaths = literalArgs.slice(0, -1);
+    if (propPaths.length === 1) {
+      return `return ${toAccess(propPaths[0])}?.endsWith(${renderLiteral(suffix)});`;
+    }
+    const checks = propPaths
+      .map((p) => `${toAccess(p)}?.endsWith(${renderLiteral(suffix)})`)
+      .join(" && ");
+    return `return ${checks};`;
+  },
+  toDependentKeys({ literalArgs }) {
+    return literalArgs.slice(0, -1);
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+/** @type {Map<string, MacroTransform>} */
+export const MACRO_TRANSFORMS = new Map([
+  // @ember/object/computed
+  ["alias", alias],
+  ["readOnly", readOnly],
+  ["reads", reads],
+  ["oneWay", oneWay],
+  ["not", not],
+  ["bool", bool],
+  ["and", and],
+  ["or", or],
+  ["equal", equal],
+  ["gt", gt],
+  ["gte", gte],
+  ["lt", lt],
+  ["lte", lte],
+  ["notEmpty", notEmpty],
+  ["empty", empty],
+  ["none", none],
+  ["match", match],
+  ["mapBy", mapBy],
+  ["filterBy", filterBy],
+  ["collect", collect],
+  ["sum", sum],
+  ["max", max],
+  ["min", min],
+  ["uniq", uniq],
+  ["uniqBy", uniqBy],
+  ["union", union],
+  ["intersect", intersect],
+  ["setDiff", setDiff],
+  ["sort", sort],
+  ["filter", filter],
+  ["map", map],
+  // discourse/lib/computed
+  ["propertyEqual", propertyEqual],
+  ["propertyNotEqual", propertyNotEqual],
+  ["propertyGreaterThan", propertyGreaterThan],
+  ["propertyLessThan", propertyLessThan],
+  ["setting", setting],
+  ["fmt", fmt],
+  ["url", url],
+  ["i18n", i18n],
+  ["computedI18n", i18n], // alias — exported as both names
+  ["htmlSafe", htmlSafe],
+  ["endWith", endWith],
+]);
+
+/** The two import sources this rule targets. */
+export const MACRO_SOURCES = new Set([
+  "@ember/object/computed",
+  "discourse/lib/computed",
+]);

--- a/lint-configs/eslint-rules/no-computed-macros/macro-transforms.mjs
+++ b/lint-configs/eslint-rules/no-computed-macros/macro-transforms.mjs
@@ -80,6 +80,9 @@ export function isLocalKey(key) {
  * @property {string} source - import source where the macro lives
  * @property {boolean} canAutoFix
  * @property {string} [reason] - explanation when canAutoFix is false
+ * @property {number} [depKeyArgCount] - how many leading args must be string
+ *   literals (dep key paths); remaining args are "value args" that can be
+ *   non-literal (their source text is used verbatim in the getter body)
  * @property {RequiredImport[]} [requiredImports]
  * @property {(args: TransformArgs) => string} [toGetterBody]
  * @property {(args: TransformArgs) => string[]} [toDependentKeys]
@@ -162,11 +165,9 @@ function comparisonMacro(operator) {
   return {
     source: EMBER_SOURCE,
     canAutoFix: true,
-    toGetterBody({ literalArgs: [path], argNodes }) {
-      const valueText =
-        argNodes[1] && argNodes[1].raw !== undefined
-          ? argNodes[1].raw
-          : renderLiteral(argNodes[1] && argNodes[1].value);
+    depKeyArgCount: 1,
+    toGetterBody({ literalArgs: [path], argNodes, sourceCode }) {
+      const valueText = sourceCode.getText(argNodes[1]);
       return `return ${toAccess(path)} ${operator} ${valueText};`;
     },
     toDependentKeys({ literalArgs: [path] }) {

--- a/lint-configs/eslint-rules/no-computed-macros/macro-transforms.mjs
+++ b/lint-configs/eslint-rules/no-computed-macros/macro-transforms.mjs
@@ -132,8 +132,35 @@ const alias = {
   },
 };
 const readOnly = { ...simpleAccess };
-const reads = { ...simpleAccess };
-const oneWay = { ...simpleAccess };
+
+// oneWay/reads: one-way binding that can be overridden locally.
+// Getter reads from source until the setter is called, then the property
+// permanently diverges. Uses a single `@tracked _propOverride` field (placed
+// in the [private-properties] section via the `_` prefix). Checking against
+// `undefined` distinguishes "never set" from "set to a value".
+const oneWayTransform = {
+  source: EMBER_SOURCE,
+  canAutoFix: true,
+  overrideTrackedFields({ propName }) {
+    return [{ name: `_${propName}Override` }];
+  },
+  toGetterBody({ literalArgs: [path], propName }) {
+    return [
+      `if (this._${propName}Override !== undefined) {`,
+      `  return this._${propName}Override;`,
+      `}`,
+      `return ${toAccess(path)};`,
+    ].join("\n");
+  },
+  toSetterBody({ propName }) {
+    return `this._${propName}Override = value;`;
+  },
+  toDependentKeys({ literalArgs: [path] }) {
+    return [path];
+  },
+};
+const reads = { ...oneWayTransform };
+const oneWay = { ...oneWayTransform };
 
 const not = {
   source: EMBER_SOURCE,
@@ -251,7 +278,7 @@ const mapBy = {
   source: EMBER_SOURCE,
   canAutoFix: true,
   toGetterBody({ literalArgs: [arrPath, prop] }) {
-    return `return ${toAccess(arrPath)}?.map((item) => item.${prop}) ?? [];`;
+    return `return ${toAccess(arrPath)}?.map?.((item) => item.${prop}) ?? [];`;
   },
   toDependentKeys({ literalArgs: [arrPath, prop] }) {
     return [`${arrPath}.@each.${prop}`];
@@ -269,9 +296,9 @@ const filterBy = {
         argNodes[2].raw !== undefined
           ? argNodes[2].raw
           : renderLiteral(argNodes[2].value);
-      return `return ${toAccess(arrPath)}?.filter((item) => item.${prop} === ${valueText}) ?? [];`;
+      return `return ${toAccess(arrPath)}?.filter?.((item) => item.${prop} === ${valueText}) ?? [];`;
     }
-    return `return ${toAccess(arrPath)}?.filter((item) => item.${prop}) ?? [];`;
+    return `return ${toAccess(arrPath)}?.filter?.((item) => item.${prop}) ?? [];`;
   },
   toDependentKeys({ literalArgs: [arrPath, prop] }) {
     return [`${arrPath}.@each.${prop}`];
@@ -299,7 +326,7 @@ const sum = {
   source: EMBER_SOURCE,
   canAutoFix: true,
   toGetterBody({ literalArgs: [path] }) {
-    return `return ${toAccess(path)}?.reduce((s, v) => s + v, 0) ?? 0;`;
+    return `return ${toAccess(path)}?.reduce?.((s, v) => s + v, 0) ?? 0;`;
   },
   toDependentKeys({ literalArgs: [path] }) {
     return [`${path}.[]`];
@@ -310,7 +337,7 @@ const max = {
   source: EMBER_SOURCE,
   canAutoFix: true,
   toGetterBody({ literalArgs: [path] }) {
-    return `return ${toAccess(path)}?.reduce((m, v) => Math.max(m, v), -Infinity) ?? -Infinity;`;
+    return `return ${toAccess(path)}?.reduce?.((m, v) => Math.max(m, v), -Infinity) ?? -Infinity;`;
   },
   toDependentKeys({ literalArgs: [path] }) {
     return [`${path}.[]`];
@@ -321,7 +348,7 @@ const min = {
   source: EMBER_SOURCE,
   canAutoFix: true,
   toGetterBody({ literalArgs: [path] }) {
-    return `return ${toAccess(path)}?.reduce((m, v) => Math.min(m, v), Infinity) ?? Infinity;`;
+    return `return ${toAccess(path)}?.reduce?.((m, v) => Math.min(m, v), Infinity) ?? Infinity;`;
   },
   toDependentKeys({ literalArgs: [path] }) {
     return [`${path}.[]`];
@@ -373,9 +400,9 @@ const intersect = {
     const last = literalArgs[literalArgs.length - 1];
     const rest = literalArgs.slice(0, -1);
     const conditions = rest
-      .map((p) => `(${toAccess(p)} ?? []).includes(item)`)
+      .map((p) => `${toAccess(p)}?.includes?.(item)`)
       .join(" && ");
-    return `return (${toAccess(last)} ?? []).filter((item) => ${conditions});`;
+    return `return ${toAccess(last)}?.filter?.((item) => ${conditions}) ?? [];`;
   },
   toDependentKeys({ literalArgs }) {
     return literalArgs.map((p) => `${p}.[]`);
@@ -386,7 +413,7 @@ const setDiff = {
   source: EMBER_SOURCE,
   canAutoFix: true,
   toGetterBody({ literalArgs: [a, b] }) {
-    return `return (${toAccess(a)} ?? []).filter((item) => !(${toAccess(b)} ?? []).includes(item));`;
+    return `return ${toAccess(a)}?.filter?.((item) => !${toAccess(b)}?.includes?.(item)) ?? [];`;
   },
   toDependentKeys({ literalArgs: [a, b] }) {
     return [`${a}.[]`, `${b}.[]`];
@@ -399,7 +426,11 @@ const sort = {
   requiredImports: [{ name: "compare", source: "@ember/utils" }],
   toGetterBody({ literalArgs: [arrPath, sortDefPath] }) {
     return [
-      `return [...(${toAccess(arrPath)} ?? [])].sort((a, b) => {`,
+      `const arr = ${toAccess(arrPath)};`,
+      `if (!Array.isArray(arr)) {`,
+      `  return [];`,
+      `}`,
+      `return [...arr].sort((a, b) => {`,
       `  for (const s of ${toAccess(sortDefPath)} ?? []) {`,
       `    const [prop, dir = "asc"] = s.split(":");`,
       `    const result = compare(a[prop], b[prop]);`,

--- a/lint-configs/eslint-rules/no-computed-macros/macro-transforms.mjs
+++ b/lint-configs/eslint-rules/no-computed-macros/macro-transforms.mjs
@@ -423,7 +423,10 @@ const setDiff = {
 const sort = {
   source: EMBER_SOURCE,
   canAutoFix: true,
-  requiredImports: [{ name: "compare", source: "@ember/utils" }],
+  requiredImports: [
+    { name: "compare", source: "@ember/utils" },
+    { name: "get", source: "@ember/object" },
+  ],
   toGetterBody({ literalArgs: [arrPath, sortDefPath] }) {
     return [
       `const arr = ${toAccess(arrPath)};`,
@@ -433,7 +436,7 @@ const sort = {
       `return [...arr].sort((a, b) => {`,
       `  for (const s of ${toAccess(sortDefPath)} ?? []) {`,
       `    const [prop, dir = "asc"] = s.split(":");`,
-      `    const result = compare(a[prop], b[prop]);`,
+      `    const result = compare(get(a, prop), get(b, prop));`,
       `    if (result !== 0) {`,
       `      return dir === "desc" ? -result : result;`,
       `    }`,

--- a/lint-configs/eslint-rules/no-computed-macros/macro-transforms.mjs
+++ b/lint-configs/eslint-rules/no-computed-macros/macro-transforms.mjs
@@ -329,7 +329,7 @@ const sum = {
     return `return ${toAccess(path)}?.reduce?.((s, v) => s + v, 0) ?? 0;`;
   },
   toDependentKeys({ literalArgs: [path] }) {
-    return [`${path}.[]`];
+    return [path];
   },
 };
 
@@ -340,7 +340,7 @@ const max = {
     return `return ${toAccess(path)}?.reduce?.((m, v) => Math.max(m, v), -Infinity) ?? -Infinity;`;
   },
   toDependentKeys({ literalArgs: [path] }) {
-    return [`${path}.[]`];
+    return [path];
   },
 };
 
@@ -351,7 +351,7 @@ const min = {
     return `return ${toAccess(path)}?.reduce?.((m, v) => Math.min(m, v), Infinity) ?? Infinity;`;
   },
   toDependentKeys({ literalArgs: [path] }) {
-    return [`${path}.[]`];
+    return [path];
   },
 };
 
@@ -371,7 +371,7 @@ const uniq = {
     return `return uniqueItemsFromArray([${spreads}]);`;
   },
   toDependentKeys({ literalArgs }) {
-    return literalArgs.map((p) => `${p}.[]`);
+    return [...literalArgs];
   },
 };
 
@@ -385,7 +385,7 @@ const uniqBy = {
     return `return uniqueItemsFromArray(${toAccess(arrPath)} ?? [], ${renderLiteral(key)});`;
   },
   toDependentKeys({ literalArgs: [arrPath] }) {
-    return [`${arrPath}.[]`];
+    return [arrPath];
   },
 };
 
@@ -405,7 +405,7 @@ const intersect = {
     return `return ${toAccess(last)}?.filter?.((item) => ${conditions}) ?? [];`;
   },
   toDependentKeys({ literalArgs }) {
-    return literalArgs.map((p) => `${p}.[]`);
+    return [...literalArgs];
   },
 };
 
@@ -416,7 +416,7 @@ const setDiff = {
     return `return ${toAccess(a)}?.filter?.((item) => !${toAccess(b)}?.includes?.(item)) ?? [];`;
   },
   toDependentKeys({ literalArgs: [a, b] }) {
-    return [`${a}.[]`, `${b}.[]`];
+    return [a, b];
   },
 };
 
@@ -443,7 +443,7 @@ const sort = {
     ].join("\n");
   },
   toDependentKeys({ literalArgs: [arrPath, sortDefPath] }) {
-    return [`${arrPath}.[]`, `${sortDefPath}.[]`];
+    return [arrPath, sortDefPath];
   },
 };
 

--- a/lint-configs/eslint-rules/no-computed-macros/macro-transforms.mjs
+++ b/lint-configs/eslint-rules/no-computed-macros/macro-transforms.mjs
@@ -424,26 +424,10 @@ const sort = {
   source: EMBER_SOURCE,
   canAutoFix: true,
   requiredImports: [
-    { name: "compare", source: "@ember/utils" },
-    { name: "get", source: "@ember/object" },
+    { name: "arraySortedByProperties", source: "discourse/lib/array-tools" },
   ],
   toGetterBody({ literalArgs: [arrPath, sortDefPath] }) {
-    return [
-      `const arr = ${toAccess(arrPath)};`,
-      `if (!Array.isArray(arr)) {`,
-      `  return [];`,
-      `}`,
-      `return [...arr].sort((a, b) => {`,
-      `  for (const s of ${toAccess(sortDefPath)} ?? []) {`,
-      `    const [prop, dir = "asc"] = s.split(":");`,
-      `    const result = compare(get(a, prop), get(b, prop));`,
-      `    if (result !== 0) {`,
-      `      return dir === "desc" ? -result : result;`,
-      `    }`,
-      `  }`,
-      `  return 0;`,
-      `});`,
-    ].join("\n");
+    return `return arraySortedByProperties(${toAccess(arrPath)}, ${toAccess(sortDefPath)});`;
   },
   toDependentKeys({ literalArgs: [arrPath, sortDefPath] }) {
     return [arrPath, sortDefPath];

--- a/lint-configs/eslint-rules/no-computed-macros/macro-transforms.mjs
+++ b/lint-configs/eslint-rules/no-computed-macros/macro-transforms.mjs
@@ -632,8 +632,14 @@ export const MACRO_TRANSFORMS = new Map([
   ["endWith", endWith],
 ]);
 
-/** The two import sources this rule targets. */
+/** The import sources this rule targets. */
 export const MACRO_SOURCES = new Set([
   "@ember/object/computed",
   "discourse/lib/computed",
+  "discourse/lib/decorators",
+]);
+
+/** Maps alternative import sources to the canonical source they alias. */
+export const SOURCE_ALIASES = new Map([
+  ["discourse/lib/decorators", "@ember/object/computed"],
 ]);

--- a/lint-configs/eslint-rules/no-computed-macros/macro-transforms.mjs
+++ b/lint-configs/eslint-rules/no-computed-macros/macro-transforms.mjs
@@ -84,7 +84,10 @@ export function isLocalKey(key) {
  *   literals (dep key paths); remaining args are "value args" that can be
  *   non-literal (their source text is used verbatim in the getter body)
  * @property {RequiredImport[]} [requiredImports]
+ * @property {RequiredImport[]} [setterRequiredImports] - extra imports needed
+ *   only when the setter uses Ember's `set()` (the `!allLocal` / `@computed` path)
  * @property {(args: TransformArgs) => string} [toGetterBody]
+ * @property {(args: SetterTransformArgs) => string} [toSetterBody]
  * @property {(args: TransformArgs) => string[]} [toDependentKeys]
  */
 
@@ -94,6 +97,12 @@ export function isLocalKey(key) {
  * @property {import('estree').Node[]} argNodes - raw AST argument nodes
  * @property {string} propName - the decorated property name
  * @property {import('eslint').SourceCode} sourceCode
+ */
+
+/**
+ * @typedef {TransformArgs & { useEmberSet: boolean }} SetterTransformArgs
+ * `useEmberSet` is true when the `@computed` path requires Ember's `set()`,
+ * false when the `@dependentKeyCompat` path uses native assignment.
  */
 
 const EMBER_SOURCE = "@ember/object/computed";
@@ -112,7 +121,16 @@ const simpleAccess = {
   },
 };
 
-const alias = { ...simpleAccess };
+const alias = {
+  ...simpleAccess,
+  setterRequiredImports: [{ name: "set", source: "@ember/object" }],
+  toSetterBody({ literalArgs: [path], useEmberSet }) {
+    if (useEmberSet) {
+      return `set(this, ${JSON.stringify(path)}, value);`;
+    }
+    return `this.${path} = value;`;
+  },
+};
 const readOnly = { ...simpleAccess };
 const reads = { ...simpleAccess };
 const oneWay = { ...simpleAccess };

--- a/lint-configs/eslint-rules/no-discourse-computed.mjs
+++ b/lint-configs/eslint-rules/no-discourse-computed.mjs
@@ -4,7 +4,7 @@ import {
   collectImports,
   getImportedLocalNames,
 } from "./utils/analyze-imports.mjs";
-import { fixImport } from "./utils/fix-import.mjs";
+import { buildImportStatement, fixImport } from "./utils/fix-import.mjs";
 
 const USE_COMPUTED_INSTEAD = "Use `@computed` instead of `@{{name}}`";
 
@@ -75,12 +75,10 @@ function fixDiscourseImport(
             })
           );
         } else {
-          fixes.push(
-            fixer.insertTextAfter(
-              importNode,
-              `\nimport { ${computedImportString} } from "@ember/object";`
-            )
-          );
+          const newImport = buildImportStatement("@ember/object", {
+            namedImports: [computedImportString],
+          });
+          fixes.push(fixer.insertTextAfter(importNode, `\n${newImport}`));
         }
       }
     } else {
@@ -103,7 +101,9 @@ function fixDiscourseImport(
           fixes.push(
             fixer.replaceText(
               importNode,
-              `import { ${computedImportString} } from "@ember/object";`
+              buildImportStatement("@ember/object", {
+                namedImports: [computedImportString],
+              })
             )
           );
         }
@@ -128,13 +128,15 @@ function fixDiscourseImport(
         }
       });
 
-      let newImportStatement = "import discourseComputed";
-      if (namedImportStrings.length > 0) {
-        newImportStatement += `, { ${namedImportStrings.join(", ")} }`;
-      }
-      newImportStatement += ` from "${importNode.source.value}";`;
-
-      fixes.push(fixer.replaceText(importNode, newImportStatement));
+      fixes.push(
+        fixer.replaceText(
+          importNode,
+          buildImportStatement(importNode.source.value, {
+            defaultImport: "discourseComputed",
+            namedImports: namedImportStrings,
+          })
+        )
+      );
     }
 
     if (!hasComputedImport) {
@@ -145,12 +147,10 @@ function fixDiscourseImport(
           })
         );
       } else {
-        fixes.push(
-          fixer.insertTextAfter(
-            importNode,
-            `\nimport { ${computedImportString} } from "@ember/object";`
-          )
-        );
+        const newImport = buildImportStatement("@ember/object", {
+          namedImports: [computedImportString],
+        });
+        fixes.push(fixer.insertTextAfter(importNode, `\n${newImport}`));
       }
     }
   }

--- a/lint-configs/eslint-rules/truth-helpers-imports.mjs
+++ b/lint-configs/eslint-rules/truth-helpers-imports.mjs
@@ -1,3 +1,5 @@
+import { buildImportStatement } from "./utils/fix-import.mjs";
+
 export default {
   meta: {
     type: "suggestion",
@@ -24,11 +26,14 @@ export default {
                 sourceName = "notEq";
               }
 
-              if (localName === sourceName) {
-                code = `import { ${localName} } from 'truth-helpers';`;
-              } else {
-                code = `import { ${sourceName} as ${localName} } from 'truth-helpers';`;
-              }
+              const namedImport =
+                localName === sourceName
+                  ? localName
+                  : `${sourceName} as ${localName}`;
+              code = buildImportStatement("truth-helpers", {
+                namedImports: [namedImport],
+                quote: "'",
+              });
 
               return fixer.replaceText(node, code);
             },

--- a/lint-configs/eslint-rules/truth-helpers-imports.mjs
+++ b/lint-configs/eslint-rules/truth-helpers-imports.mjs
@@ -32,7 +32,6 @@ export default {
                   : `${sourceName} as ${localName}`;
               code = buildImportStatement("truth-helpers", {
                 namedImports: [namedImport],
-                quote: "'",
               });
 
               return fixer.replaceText(node, code);

--- a/lint-configs/eslint-rules/utils/fix-import.mjs
+++ b/lint-configs/eslint-rules/utils/fix-import.mjs
@@ -1,4 +1,32 @@
 /**
+ * Build an import statement string from its parts.
+ *
+ * @param {string} source - The import source (e.g. "@ember/object").
+ * @param {Object} [options]
+ * @param {string|null} [options.defaultImport] - Default import name, or null.
+ * @param {string[]} [options.namedImports] - Named import specifiers (may include aliases like "foo as bar").
+ * @param {string} [options.quote] - Quote style: `"` (default) or `'`.
+ * @returns {string} A complete import statement string.
+ */
+export function buildImportStatement(
+  source,
+  { defaultImport = null, namedImports = [], quote = '"' } = {}
+) {
+  let stmt = "import ";
+  if (defaultImport) {
+    stmt += defaultImport;
+    if (namedImports.length > 0) {
+      stmt += ", ";
+    }
+  }
+  if (namedImports.length > 0) {
+    stmt += `{ ${namedImports.join(", ")} }`;
+  }
+  stmt += ` from ${quote}${source}${quote};`;
+  return stmt;
+}
+
+/**
  * Fix an import declaration
  *
  * @param {ASTNode} importDeclarationNode - The AST node representing the import declaration.
@@ -51,18 +79,10 @@ export function fixImport(
     ])
   );
 
-  // Construct the new import statement
-  let newImportStatement = "import ";
-  if (finalDefaultImport) {
-    newImportStatement += `${finalDefaultImport}`;
-    if (finalNamedImports.length > 0) {
-      newImportStatement += ", ";
-    }
-  }
-  if (finalNamedImports.length > 0) {
-    newImportStatement += `{ ${finalNamedImports.join(", ")} }`;
-  }
-  newImportStatement += ` from "${importDeclarationNode.source.value}";`;
+  const newImportStatement = buildImportStatement(
+    importDeclarationNode.source.value,
+    { defaultImport: finalDefaultImport, namedImports: finalNamedImports }
+  );
 
   // Replace the entire import declaration
   return fixer.replaceText(importDeclarationNode, newImportStatement);

--- a/lint-configs/eslint-rules/utils/fix-import.mjs
+++ b/lint-configs/eslint-rules/utils/fix-import.mjs
@@ -10,7 +10,7 @@
  */
 export function buildImportStatement(
   source,
-  { defaultImport = null, namedImports = [], quote = '"' } = {}
+  { defaultImport = null, namedImports = [] } = {}
 ) {
   let stmt = "import ";
   if (defaultImport) {
@@ -22,7 +22,7 @@ export function buildImportStatement(
   if (namedImports.length > 0) {
     stmt += `{ ${namedImports.join(", ")} }`;
   }
-  stmt += ` from ${quote}${source}${quote};`;
+  stmt += ` from "${source}";`;
   return stmt;
 }
 

--- a/lint-configs/eslint.mjs
+++ b/lint-configs/eslint.mjs
@@ -22,6 +22,7 @@ import lineAfterImports from "./eslint-rules/line-after-imports.mjs";
 import lineBeforeDefaultExport from "./eslint-rules/line-before-default-export.mjs";
 import linesBetweenClassMembers from "./eslint-rules/lines-between-class-members.mjs";
 import movedPackagesImportPaths from "./eslint-rules/moved-packages-import-paths.mjs";
+import noComputedMacros from "./eslint-rules/no-computed-macros.mjs";
 import noCurlyComponents from "./eslint-rules/no-curly-components.mjs";
 import noDiscourseComputed from "./eslint-rules/no-discourse-computed.mjs";
 import noOnclick from "./eslint-rules/no-onclick.mjs";
@@ -144,6 +145,7 @@ export default [
           "no-route-template": noRouteTemplate,
           "template-tag-no-self-this": templateTagNoSelfThis,
           "moved-packages-import-paths": movedPackagesImportPaths,
+          "no-computed-macros": noComputedMacros,
           "no-discourse-computed": noDiscourseComputed,
           "test-filename-suffix": testFilenameSuffix,
         },
@@ -315,8 +317,9 @@ export default [
       "discourse/no-route-template": ["error"],
       "discourse/moved-packages-import-paths": ["error"],
       "discourse/test-filename-suffix": ["error"],
-      "discourse/keep-array-sorted": ["error"],
+      "discourse/no-computed-macros": ["error"],
       "discourse/no-discourse-computed": ["error"],
+      "discourse/keep-array-sorted": ["error"],
     },
   },
   {

--- a/lint-configs/package.json
+++ b/lint-configs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@discourse/lint-configs",
-  "version": "2.44.1",
+  "version": "2.45.0",
   "description": "Shareable lint configs for Discourse core, plugins, and themes",
   "author": "Discourse",
   "license": "MIT",

--- a/lint-configs/package.json
+++ b/lint-configs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@discourse/lint-configs",
-  "version": "2.41.0",
+  "version": "2.42.0",
   "description": "Shareable lint configs for Discourse core, plugins, and themes",
   "author": "Discourse",
   "license": "MIT",

--- a/test/eslint-rules/no-computed-macros.test.mjs
+++ b/test/eslint-rules/no-computed-macros.test.mjs
@@ -81,6 +81,7 @@ class C {
 import { dependentKeyCompat } from "@ember/object/compat";
 class C {
   @tracked name;
+
   @dependentKeyCompat
   get myName() {
     return this.name;
@@ -117,6 +118,7 @@ class C {
 import { dependentKeyCompat } from "@ember/object/compat";
 class C {
   @tracked isHidden;
+
   @dependentKeyCompat
   get isVisible() {
     return !this.isHidden;
@@ -136,6 +138,7 @@ class C {
 import { dependentKeyCompat } from "@ember/object/compat";
 class C {
   @tracked count;
+
   @dependentKeyCompat
   get hasItems() {
     return !!this.count;
@@ -156,6 +159,7 @@ import { dependentKeyCompat } from "@ember/object/compat";
 class C {
   @tracked pinned;
   @tracked readLastPost;
+
   @dependentKeyCompat
   get canClearPin() {
     return this.pinned && this.readLastPost;
@@ -192,6 +196,7 @@ class C {
 import { dependentKeyCompat } from "@ember/object/compat";
 class C {
   @tracked trust_level;
+
   @dependentKeyCompat
   get isBasic() {
     return this.trust_level === 0;
@@ -264,6 +269,7 @@ class C {
 import { dependentKeyCompat } from "@ember/object/compat";
 class C {
   @tracked id;
+
   @dependentKeyCompat
   get isNew() {
     return this.id == null;
@@ -379,6 +385,7 @@ import { dependentKeyCompat } from "@ember/object/compat";
 class C {
   @tracked a;
   @tracked b;
+
   @dependentKeyCompat
   get items() {
     return [this.a === undefined ? null : this.a, this.b === undefined ? null : this.b];
@@ -518,6 +525,7 @@ import { dependentKeyCompat } from "@ember/object/compat";
 class C {
   @tracked originalTrustLevel;
   @tracked trust_level;
+
   @dependentKeyCompat
   get dirty() {
     return !deepEqual(this.originalTrustLevel, this.trust_level);
@@ -554,6 +562,7 @@ class C {
 import { dependentKeyCompat } from "@ember/object/compat";
 class C {
   @tracked url;
+
   @dependentKeyCompat
   get printUrl() {
     return \`\${this.url}/print\`;
@@ -575,6 +584,7 @@ import { dependentKeyCompat } from "@ember/object/compat";
 class C {
   @tracked id;
   @tracked username_lower;
+
   @dependentKeyCompat
   get adminPath() {
     return getURL(\`/admin/users/\${this.id}/\${this.username_lower}\`);
@@ -595,6 +605,7 @@ import { tracked } from "@glimmer/tracking";
 import { dependentKeyCompat } from "@ember/object/compat";
 class C {
   @tracked action_type;
+
   @dependentKeyCompat
   get description() {
     return i18n(\`user_action_groups.\${this.action_type}\`);
@@ -613,6 +624,7 @@ import { tracked } from "@glimmer/tracking";
 import { dependentKeyCompat } from "@ember/object/compat";
 class C {
   @tracked action_type;
+
   @dependentKeyCompat
   get description() {
     return i18n(\`user_action_groups.\${this.action_type}\`);
@@ -633,6 +645,7 @@ import { tracked } from "@glimmer/tracking";
 import { dependentKeyCompat } from "@ember/object/compat";
 class C {
   @tracked bio;
+
   @dependentKeyCompat
   get safeBio() {
     return htmlSafe(this.bio);
@@ -652,6 +665,7 @@ class C {
 import { dependentKeyCompat } from "@ember/object/compat";
 class C {
   @tracked name;
+
   @dependentKeyCompat
   get isJsFile() {
     return this.name?.endsWith(".js");
@@ -673,6 +687,7 @@ class C {
 import { dependentKeyCompat } from "@ember/object/compat";
 class C {
   @tracked isHidden;
+
   @dependentKeyCompat
   get isVisible() {
     return !this.isHidden;
@@ -686,11 +701,16 @@ class C {
   headerLang = null;
   @alias("headerLang") lang;
 }`,
-      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      errors: [
+        { messageId: "replaceMacro" },
+        { messageId: "addTracked" },
+        { messageId: "replaceMacro" },
+      ],
       output: `import { tracked } from "@glimmer/tracking";
 import { dependentKeyCompat } from "@ember/object/compat";
 class C {
   @tracked headerLang = null;
+
   @dependentKeyCompat
   get lang() {
     return this.headerLang;
@@ -714,6 +734,7 @@ import { tracked } from "@glimmer/tracking";
 import { dependentKeyCompat } from "@ember/object/compat";
 class C {
   @tracked name;
+
   @dependentKeyCompat
   get title() {
     return i18n(\`group.\${this.name}.title\`);
@@ -763,6 +784,7 @@ class C {
 import { dependentKeyCompat } from "@ember/object/compat";
 class C {
   @tracked enabled;
+
   @dependentKeyCompat
   get disabled() {
     return !this.enabled;
@@ -770,6 +792,113 @@ class C {
   @dependentKeyCompat
   get isDisabled() {
     return this.disabled;
+  }
+}`,
+    },
+
+    // ---- @equal with non-literal value arg ----
+    {
+      name: "@equal with constant value arg auto-fixes using source text",
+      code: `import { equal } from "@ember/object/computed";
+const CREATE_TOPIC = 1;
+class C {
+  @equal("action", CREATE_TOPIC) isCreate;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { tracked } from "@glimmer/tracking";
+import { dependentKeyCompat } from "@ember/object/compat";
+const CREATE_TOPIC = 1;
+class C {
+  @tracked action;
+
+  @dependentKeyCompat
+  get isCreate() {
+    return this.action === CREATE_TOPIC;
+  }
+}`,
+    },
+    {
+      name: "@gte with non-literal value arg",
+      code: `import { gte } from "@ember/object/computed";
+const MIN_COUNT = 5;
+class C {
+  @gte("count", MIN_COUNT) hasEnough;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { tracked } from "@glimmer/tracking";
+import { dependentKeyCompat } from "@ember/object/compat";
+const MIN_COUNT = 5;
+class C {
+  @tracked count;
+
+  @dependentKeyCompat
+  get hasEnough() {
+    return this.count >= MIN_COUNT;
+  }
+}`,
+    },
+    {
+      name: "@equal with member expression value arg",
+      code: `import { equal } from "@ember/object/computed";
+class C {
+  @equal("action_type", UserActionTypes.replies) isReply;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { tracked } from "@glimmer/tracking";
+import { dependentKeyCompat } from "@ember/object/compat";
+class C {
+  @tracked action_type;
+
+  @dependentKeyCompat
+  get isReply() {
+    return this.action_type === UserActionTypes.replies;
+  }
+}`,
+    },
+
+    // ---- @tracked on existing member does not block other fixes ----
+    {
+      name: "@tracked on existing member does not block other property fixes",
+      code: `import { alias, gte, not } from "@ember/object/computed";
+class C {
+  @alias("model.title") title;
+  @not("isHidden") isVisible;
+  @gte("topicPostCount", 2) hasReplies;
+  topicPostCount = 0;
+  @alias("model.featured") showFeaturedTopic;
+}`,
+      errors: [
+        { messageId: "replaceMacro" },
+        { messageId: "replaceMacro" },
+        { messageId: "replaceMacro" },
+        { messageId: "replaceMacro" },
+        { messageId: "replaceMacro" },
+        { messageId: "replaceMacro" },
+        { messageId: "addTracked" },
+        { messageId: "replaceMacro" },
+      ],
+      output: `import { tracked } from "@glimmer/tracking";
+import { computed } from "@ember/object";
+import { dependentKeyCompat } from "@ember/object/compat";
+class C {
+  @tracked isHidden;
+  @tracked topicPostCount = 0;
+
+  @computed("model.title")
+  get title() {
+    return this.model?.title;
+  }
+  @dependentKeyCompat
+  get isVisible() {
+    return !this.isHidden;
+  }
+  @dependentKeyCompat
+  get hasReplies() {
+    return this.topicPostCount >= 2;
+  }
+  @computed("model.featured")
+  get showFeaturedTopic() {
+    return this.model?.featured;
   }
 }`,
     },
@@ -856,15 +985,62 @@ import { tracked } from "@glimmer/tracking";
 import { computed } from "@ember/object";
 import { dependentKeyCompat } from "@ember/object/compat";
 class C {
+  @tracked a;
+  @tracked b;
+
   @computed("items.length")
   get hasItems() {
     return !isEmpty(this.items);
   }
-  @tracked a;
-  @tracked b;
   @dependentKeyCompat
   get isDifferent() {
     return !deepEqual(this.a, this.b);
+  }
+}`,
+    },
+    // ---- static methods should not affect getter insertion point ----
+    {
+      name: "getters are placed after instance properties, not among static methods",
+      code: `import { alias, not } from "@ember/object/computed";
+class C {
+  static find(id) {
+    return id;
+  }
+  @tracked isHidden;
+  message = null;
+  @alias("model.title") title;
+  @not("isHidden") isVisible;
+  @computed("last_read_post_number")
+  get visited() {
+    return this.last_read_post_number > 0;
+  }
+}`,
+      errors: [
+        { messageId: "replaceMacro" },
+        { messageId: "replaceMacro" },
+        { messageId: "replaceMacro" },
+        { messageId: "replaceMacro" },
+      ],
+      output: `import { computed } from "@ember/object";
+import { dependentKeyCompat } from "@ember/object/compat";
+class C {
+  static find(id) {
+    return id;
+  }
+  @tracked isHidden;
+  message = null;
+
+  @computed("model.title")
+  get title() {
+    return this.model?.title;
+  }
+  @dependentKeyCompat
+  get isVisible() {
+    return !this.isHidden;
+  }
+  @computed("last_read_post_number")
+  get visited() {
+    return this.last_read_post_number > 0;
   }
 }`,
     },

--- a/test/eslint-rules/no-computed-macros.test.mjs
+++ b/test/eslint-rules/no-computed-macros.test.mjs
@@ -49,6 +49,13 @@ class C {
   }
 }`,
     },
+    {
+      name: "classic .extend() usage is ignored",
+      code: `import { alias } from "@ember/object/computed";
+const Foo = EmberObject.extend({
+  title: alias("model.title"),
+});`,
+    },
   ],
 
   invalid: [
@@ -962,19 +969,6 @@ class C {
     return this.pinned && this.category?.isUncategorizedCategory;
   }
 }`,
-    },
-
-    // ---- classic .extend() → report only ----
-    {
-      name: "classic .extend() class reports without fix",
-      code: `import { alias } from "@ember/object/computed";
-const Foo = EmberObject.extend({
-  title: alias("model.title"),
-});`,
-      errors: [
-        { messageId: "replaceMacro" },
-        { messageId: "cannotAutoFixClassic" },
-      ],
     },
 
     // ---- non-literal args → report only ----

--- a/test/eslint-rules/no-computed-macros.test.mjs
+++ b/test/eslint-rules/no-computed-macros.test.mjs
@@ -1,0 +1,823 @@
+import EmberESLintParser from "ember-eslint-parser";
+import { RuleTester } from "eslint";
+import rule from "../../lint-configs/eslint-rules/no-computed-macros.mjs";
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: EmberESLintParser,
+    parserOptions: {
+      ecmaVersion: 2022,
+      sourceType: "module",
+      ecmaFeatures: {
+        legacyDecorators: true,
+        classFields: true,
+      },
+    },
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+ruleTester.run("no-computed-macros", rule, {
+  valid: [
+    {
+      name: "native getter with @computed is fine",
+      code: `import { computed } from "@ember/object";
+class C {
+  @computed("model.title")
+  get title() {
+    return this.model?.title;
+  }
+}`,
+    },
+    {
+      name: "import from non-macro source is fine",
+      code: `import { something } from "some-other-package";
+class C {
+  @something("foo") bar;
+}`,
+    },
+    {
+      name: "non-macro import from @ember/object/computed is fine",
+      code: `import { computed } from "@ember/object";
+class C {
+  @computed("foo")
+  get bar() {
+    return this.foo;
+  }
+}`,
+    },
+  ],
+
+  invalid: [
+    // ---- alias (nested dep → @computed) ----
+    {
+      name: "@alias with nested path → @computed getter",
+      code: `import { alias } from "@ember/object/computed";
+class C {
+  @alias("model.title") title;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { computed } from "@ember/object";
+class C {
+  @computed("model.title")
+  get title() {
+    return this.model?.title;
+  }
+}`,
+    },
+
+    // ---- alias (local dep → @dependentKeyCompat + @tracked) ----
+    {
+      name: "@alias with local path → @dependentKeyCompat + @tracked",
+      code: `import { alias } from "@ember/object/computed";
+class C {
+  @alias("name") myName;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { tracked } from "@glimmer/tracking";
+import { dependentKeyCompat } from "@ember/object/compat";
+class C {
+  @tracked name;
+  @dependentKeyCompat
+  get myName() {
+    return this.name;
+  }
+}`,
+    },
+
+    // ---- readOnly (nested) ----
+    {
+      name: "@readOnly with nested path",
+      code: `import { readOnly } from "@ember/object/computed";
+class C {
+  @readOnly("model.items") modelItems;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { computed } from "@ember/object";
+class C {
+  @computed("model.items")
+  get modelItems() {
+    return this.model?.items;
+  }
+}`,
+    },
+
+    // ---- not (local) ----
+    {
+      name: "@not with local dep",
+      code: `import { not } from "@ember/object/computed";
+class C {
+  @not("isHidden") isVisible;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { tracked } from "@glimmer/tracking";
+import { dependentKeyCompat } from "@ember/object/compat";
+class C {
+  @tracked isHidden;
+  @dependentKeyCompat
+  get isVisible() {
+    return !this.isHidden;
+  }
+}`,
+    },
+
+    // ---- bool ----
+    {
+      name: "@bool with local dep",
+      code: `import { bool } from "@ember/object/computed";
+class C {
+  @bool("count") hasItems;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { tracked } from "@glimmer/tracking";
+import { dependentKeyCompat } from "@ember/object/compat";
+class C {
+  @tracked count;
+  @dependentKeyCompat
+  get hasItems() {
+    return !!this.count;
+  }
+}`,
+    },
+
+    // ---- and (local) ----
+    {
+      name: "@and with local deps",
+      code: `import { and } from "@ember/object/computed";
+class C {
+  @and("pinned", "readLastPost") canClearPin;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { tracked } from "@glimmer/tracking";
+import { dependentKeyCompat } from "@ember/object/compat";
+class C {
+  @tracked pinned;
+  @tracked readLastPost;
+  @dependentKeyCompat
+  get canClearPin() {
+    return this.pinned && this.readLastPost;
+  }
+}`,
+    },
+
+    // ---- or (nested) ----
+    {
+      name: "@or with nested deps",
+      code: `import { or } from "@ember/object/computed";
+class C {
+  @or("details.can_edit", "details.can_edit_tags") canEditTags;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { computed } from "@ember/object";
+class C {
+  @computed("details.can_edit", "details.can_edit_tags")
+  get canEditTags() {
+    return this.details?.can_edit || this.details?.can_edit_tags;
+  }
+}`,
+    },
+
+    // ---- equal ----
+    {
+      name: "@equal with local dep",
+      code: `import { equal } from "@ember/object/computed";
+class C {
+  @equal("trust_level", 0) isBasic;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { tracked } from "@glimmer/tracking";
+import { dependentKeyCompat } from "@ember/object/compat";
+class C {
+  @tracked trust_level;
+  @dependentKeyCompat
+  get isBasic() {
+    return this.trust_level === 0;
+  }
+}`,
+    },
+
+    // ---- gt (nested) ----
+    {
+      name: "@gt with nested dep",
+      code: `import { gt } from "@ember/object/computed";
+class C {
+  @gt("private_messages_stats.all", 0) hasPMs;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { computed } from "@ember/object";
+class C {
+  @computed("private_messages_stats.all")
+  get hasPMs() {
+    return this.private_messages_stats?.all > 0;
+  }
+}`,
+    },
+
+    // ---- notEmpty ----
+    {
+      name: "@notEmpty with local dep (dep key uses .length)",
+      code: `import { notEmpty } from "@ember/object/computed";
+class C {
+  @notEmpty("deleted_at") deleted;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { isEmpty } from "@ember/utils";
+import { computed } from "@ember/object";
+class C {
+  @computed("deleted_at.length")
+  get deleted() {
+    return !isEmpty(this.deleted_at);
+  }
+}`,
+    },
+
+    // ---- empty ----
+    {
+      name: "@empty with local dep",
+      code: `import { empty } from "@ember/object/computed";
+class C {
+  @empty("items") noItems;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { isEmpty } from "@ember/utils";
+import { computed } from "@ember/object";
+class C {
+  @computed("items.length")
+  get noItems() {
+    return isEmpty(this.items);
+  }
+}`,
+    },
+
+    // ---- none ----
+    {
+      name: "@none with local dep",
+      code: `import { none } from "@ember/object/computed";
+class C {
+  @none("id") isNew;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { tracked } from "@glimmer/tracking";
+import { dependentKeyCompat } from "@ember/object/compat";
+class C {
+  @tracked id;
+  @dependentKeyCompat
+  get isNew() {
+    return this.id == null;
+  }
+}`,
+    },
+
+    // ---- match (nested) ----
+    {
+      name: "@match with nested dep",
+      code: `import { match } from "@ember/object/computed";
+class C {
+  @match("model.url", /^https?:\\/\\//) isHttp;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { computed } from "@ember/object";
+class C {
+  @computed("model.url")
+  get isHttp() {
+    return /^https?:\\/\\//.test(this.model?.url);
+  }
+}`,
+    },
+
+    // ---- mapBy ----
+    {
+      name: "@mapBy always uses @computed (dep has @each)",
+      code: `import { mapBy } from "@ember/object/computed";
+class C {
+  @mapBy("themes", "name") themeNames;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { computed } from "@ember/object";
+class C {
+  @computed("themes.@each.name")
+  get themeNames() {
+    return this.themes?.map((item) => item.name) ?? [];
+  }
+}`,
+    },
+
+    // ---- filterBy without value ----
+    {
+      name: "@filterBy without value arg",
+      code: `import { filterBy } from "@ember/object/computed";
+class C {
+  @filterBy("groups", "has_messages") groupsWithMessages;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { computed } from "@ember/object";
+class C {
+  @computed("groups.@each.has_messages")
+  get groupsWithMessages() {
+    return this.groups?.filter((item) => item.has_messages) ?? [];
+  }
+}`,
+    },
+
+    // ---- filterBy with value ----
+    {
+      name: "@filterBy with value arg",
+      code: `import { filterBy } from "@ember/object/computed";
+class C {
+  @filterBy("model", "is_favorite", true) favoriteBadges;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { computed } from "@ember/object";
+class C {
+  @computed("model.@each.is_favorite")
+  get favoriteBadges() {
+    return this.model?.filter((item) => item.is_favorite === true) ?? [];
+  }
+}`,
+    },
+
+    // ---- sort ----
+    {
+      name: "@sort with two deps",
+      code: `import { sort } from "@ember/object/computed";
+class C {
+  @sort("categories", "sortDef") sorted;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { compare } from "@ember/utils";
+import { computed } from "@ember/object";
+class C {
+  @computed("categories.[]", "sortDef.[]")
+  get sorted() {
+    return [...(this.categories ?? [])].sort((a, b) => {
+      for (const s of this.sortDef ?? []) {
+        const [prop, dir = "asc"] = s.split(":");
+        const result = compare(a[prop], b[prop]);
+        if (result !== 0) {
+          return dir === "desc" ? -result : result;
+        }
+      }
+      return 0;
+    });
+  }
+}`,
+    },
+
+    // ---- collect (local) ----
+    {
+      name: "@collect with local deps",
+      code: `import { collect } from "@ember/object/computed";
+class C {
+  @collect("a", "b") items;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { tracked } from "@glimmer/tracking";
+import { dependentKeyCompat } from "@ember/object/compat";
+class C {
+  @tracked a;
+  @tracked b;
+  @dependentKeyCompat
+  get items() {
+    return [this.a === undefined ? null : this.a, this.b === undefined ? null : this.b];
+  }
+}`,
+    },
+
+    // ---- uniq ----
+    {
+      name: "@uniq macro",
+      code: `import { uniq } from "@ember/object/computed";
+class C {
+  @uniq("items") uniqueItems;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { uniqueItemsFromArray } from "discourse/lib/array-tools";
+import { computed } from "@ember/object";
+class C {
+  @computed("items.[]")
+  get uniqueItems() {
+    return uniqueItemsFromArray(this.items ?? []);
+  }
+}`,
+    },
+
+    // ---- union ----
+    {
+      name: "@union macro with two arrays",
+      code: `import { union } from "@ember/object/computed";
+class C {
+  @union("a", "b") combined;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { uniqueItemsFromArray } from "discourse/lib/array-tools";
+import { computed } from "@ember/object";
+class C {
+  @computed("a.[]", "b.[]")
+  get combined() {
+    return uniqueItemsFromArray([...(this.a ?? []), ...(this.b ?? [])]);
+  }
+}`,
+    },
+
+    // ---- intersect ----
+    {
+      name: "@intersect macro",
+      code: `import { intersect } from "@ember/object/computed";
+class C {
+  @intersect("a", "b") common;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { computed } from "@ember/object";
+class C {
+  @computed("a.[]", "b.[]")
+  get common() {
+    return (this.b ?? []).filter((item) => (this.a ?? []).includes(item));
+  }
+}`,
+    },
+
+    // ---- setDiff ----
+    {
+      name: "@setDiff macro",
+      code: `import { setDiff } from "@ember/object/computed";
+class C {
+  @setDiff("a", "b") diff;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { computed } from "@ember/object";
+class C {
+  @computed("a.[]", "b.[]")
+  get diff() {
+    return (this.a ?? []).filter((item) => !(this.b ?? []).includes(item));
+  }
+}`,
+    },
+
+    // ---- sum ----
+    {
+      name: "@sum macro",
+      code: `import { sum } from "@ember/object/computed";
+class C {
+  @sum("values") total;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { computed } from "@ember/object";
+class C {
+  @computed("values.[]")
+  get total() {
+    return this.values?.reduce((s, v) => s + v, 0) ?? 0;
+  }
+}`,
+    },
+
+    // ---- filter (non-fixable) ----
+    {
+      name: "@filter with callback is not auto-fixable",
+      code: `import { filter } from "@ember/object/computed";
+class C {
+  @filter("categories", function(c) { return !c.get("parentCategory"); }) parentCategories;
+}`,
+      errors: [
+        { messageId: "replaceMacro" },
+        { messageId: "cannotAutoFixComplex" },
+      ],
+    },
+
+    // ---- discourse/lib/computed: propertyEqual (nested) ----
+    {
+      name: "@propertyEqual with nested deps",
+      code: `import { propertyEqual } from "discourse/lib/computed";
+class C {
+  @propertyEqual("topic.details.created_by.id", "user_id") topicOwner;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { deepEqual } from "discourse/lib/object";
+import { computed } from "@ember/object";
+class C {
+  @computed("topic.details.created_by.id", "user_id")
+  get topicOwner() {
+    return deepEqual(this.topic?.details?.created_by?.id, this.user_id);
+  }
+}`,
+    },
+
+    // ---- propertyNotEqual (local) ----
+    {
+      name: "@propertyNotEqual with local deps",
+      code: `import { propertyNotEqual } from "discourse/lib/computed";
+class C {
+  @propertyNotEqual("originalTrustLevel", "trust_level") dirty;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { deepEqual } from "discourse/lib/object";
+import { tracked } from "@glimmer/tracking";
+import { dependentKeyCompat } from "@ember/object/compat";
+class C {
+  @tracked originalTrustLevel;
+  @tracked trust_level;
+  @dependentKeyCompat
+  get dirty() {
+    return !deepEqual(this.originalTrustLevel, this.trust_level);
+  }
+}`,
+    },
+
+    // ---- setting ----
+    {
+      name: "@setting always produces @computed (nested: siteSettings.x)",
+      code: `import { setting } from "discourse/lib/computed";
+class C {
+  @setting("title") siteTitle;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { computed } from "@ember/object";
+class C {
+  @computed("siteSettings.title")
+  get siteTitle() {
+    return this.siteSettings.title;
+  }
+}`,
+    },
+
+    // ---- fmt (local) ----
+    {
+      name: "@fmt with local dep",
+      code: `import { fmt } from "discourse/lib/computed";
+class C {
+  @fmt("url", "%@/print") printUrl;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { tracked } from "@glimmer/tracking";
+import { dependentKeyCompat } from "@ember/object/compat";
+class C {
+  @tracked url;
+  @dependentKeyCompat
+  get printUrl() {
+    return \`\${this.url}/print\`;
+  }
+}`,
+    },
+
+    // ---- url (local) ----
+    {
+      name: "@url with local deps",
+      code: `import { url } from "discourse/lib/computed";
+class C {
+  @url("id", "username_lower", "/admin/users/%@1/%@2") adminPath;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import getURL from "discourse/lib/get-url";
+import { tracked } from "@glimmer/tracking";
+import { dependentKeyCompat } from "@ember/object/compat";
+class C {
+  @tracked id;
+  @tracked username_lower;
+  @dependentKeyCompat
+  get adminPath() {
+    return getURL(\`/admin/users/\${this.id}/\${this.username_lower}\`);
+  }
+}`,
+    },
+
+    // ---- i18n ----
+    {
+      name: "@i18n with local dep",
+      code: `import { i18n } from "discourse/lib/computed";
+class C {
+  @i18n("action_type", "user_action_groups.%@") description;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { i18n } from "discourse-i18n";
+import { tracked } from "@glimmer/tracking";
+import { dependentKeyCompat } from "@ember/object/compat";
+class C {
+  @tracked action_type;
+  @dependentKeyCompat
+  get description() {
+    return i18n(\`user_action_groups.\${this.action_type}\`);
+  }
+}`,
+    },
+    {
+      name: "@computedI18n alias",
+      code: `import { computedI18n } from "discourse/lib/computed";
+class C {
+  @computedI18n("action_type", "user_action_groups.%@") description;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { i18n } from "discourse-i18n";
+import { tracked } from "@glimmer/tracking";
+import { dependentKeyCompat } from "@ember/object/compat";
+class C {
+  @tracked action_type;
+  @dependentKeyCompat
+  get description() {
+    return i18n(\`user_action_groups.\${this.action_type}\`);
+  }
+}`,
+    },
+
+    // ---- htmlSafe ----
+    {
+      name: "@htmlSafe with local dep",
+      code: `import { htmlSafe } from "discourse/lib/computed";
+class C {
+  @htmlSafe("bio") safeBio;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { htmlSafe } from "@ember/template";
+import { tracked } from "@glimmer/tracking";
+import { dependentKeyCompat } from "@ember/object/compat";
+class C {
+  @tracked bio;
+  @dependentKeyCompat
+  get safeBio() {
+    return htmlSafe(this.bio);
+  }
+}`,
+    },
+
+    // ---- endWith ----
+    {
+      name: "@endWith with local dep",
+      code: `import { endWith } from "discourse/lib/computed";
+class C {
+  @endWith("name", ".js") isJsFile;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { tracked } from "@glimmer/tracking";
+import { dependentKeyCompat } from "@ember/object/compat";
+class C {
+  @tracked name;
+  @dependentKeyCompat
+  get isJsFile() {
+    return this.name?.endsWith(".js");
+  }
+}`,
+    },
+
+    // ---- existing @tracked dep should not be duplicated ----
+    {
+      name: "does not add @tracked for already tracked deps",
+      code: `import { tracked } from "@glimmer/tracking";
+import { not } from "@ember/object/computed";
+class C {
+  @tracked isHidden;
+  @not("isHidden") isVisible;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { tracked } from "@glimmer/tracking";
+import { dependentKeyCompat } from "@ember/object/compat";
+class C {
+  @tracked isHidden;
+  @dependentKeyCompat
+  get isVisible() {
+    return !this.isHidden;
+  }
+}`,
+    },
+    {
+      name: "adds @tracked to existing member without it",
+      code: `import { alias } from "@ember/object/computed";
+class C {
+  headerLang = null;
+  @alias("headerLang") lang;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { tracked } from "@glimmer/tracking";
+import { dependentKeyCompat } from "@ember/object/compat";
+class C {
+  @tracked headerLang = null;
+  @dependentKeyCompat
+  get lang() {
+    return this.headerLang;
+  }
+}`,
+    },
+    {
+      name: "two macros sharing same dep do not duplicate @tracked",
+      code: `import { i18n } from "discourse/lib/computed";
+class C {
+  @i18n("name", "group.%@.title") title;
+  @i18n("name", "group.%@.help") help;
+}`,
+      errors: [
+        { messageId: "replaceMacro" },
+        { messageId: "replaceMacro" },
+        { messageId: "replaceMacro" },
+      ],
+      output: `import { i18n } from "discourse-i18n";
+import { tracked } from "@glimmer/tracking";
+import { dependentKeyCompat } from "@ember/object/compat";
+class C {
+  @tracked name;
+  @dependentKeyCompat
+  get title() {
+    return i18n(\`group.\${this.name}.title\`);
+  }
+  @dependentKeyCompat
+  get help() {
+    return i18n(\`group.\${this.name}.help\`);
+  }
+}`,
+    },
+
+    // ---- import alias ----
+    {
+      name: "handles import aliases",
+      code: `import { alias as emberAlias } from "@ember/object/computed";
+class C {
+  @emberAlias("model.title") title;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { computed } from "@ember/object";
+class C {
+  @computed("model.title")
+  get title() {
+    return this.model?.title;
+  }
+}`,
+    },
+
+    // ---- mixed local/nested deps → @computed wins ----
+    {
+      name: "mixed local and nested deps → uses @computed",
+      code: `import { and } from "@ember/object/computed";
+class C {
+  @and("pinned", "category.isUncategorizedCategory") isPinnedUncategorized;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { computed } from "@ember/object";
+class C {
+  @computed("pinned", "category.isUncategorizedCategory")
+  get isPinnedUncategorized() {
+    return this.pinned && this.category?.isUncategorizedCategory;
+  }
+}`,
+    },
+
+    // ---- classic .extend() → report only ----
+    {
+      name: "classic .extend() class reports without fix",
+      code: `import { alias } from "@ember/object/computed";
+const Foo = EmberObject.extend({
+  title: alias("model.title"),
+});`,
+      errors: [
+        { messageId: "replaceMacro" },
+        { messageId: "cannotAutoFixClassic" },
+      ],
+    },
+
+    // ---- non-literal args → report only ----
+    {
+      name: "non-literal args are not auto-fixable",
+      code: `import { alias } from "@ember/object/computed";
+const key = "model.title";
+class C {
+  @alias(key) title;
+}`,
+      errors: [
+        { messageId: "replaceMacro" },
+        { messageId: "cannotAutoFixDynamic" },
+      ],
+    },
+
+    // ---- dual source: macros from both @ember/object/computed AND discourse/lib/computed ----
+    {
+      name: "dual source does not duplicate shared imports",
+      code: `import { notEmpty } from "@ember/object/computed";
+import { propertyNotEqual } from "discourse/lib/computed";
+class C {
+  @notEmpty("items") hasItems;
+  @propertyNotEqual("a", "b") isDifferent;
+}`,
+      errors: [
+        { messageId: "replaceMacro" },
+        { messageId: "replaceMacro" },
+        { messageId: "replaceMacro" },
+        { messageId: "replaceMacro" },
+      ],
+      output: `import { isEmpty } from "@ember/utils";
+import { deepEqual } from "discourse/lib/object";
+import { tracked } from "@glimmer/tracking";
+import { computed } from "@ember/object";
+import { dependentKeyCompat } from "@ember/object/compat";
+class C {
+  @computed("items.length")
+  get hasItems() {
+    return !isEmpty(this.items);
+  }
+  @tracked a;
+  @tracked b;
+  @dependentKeyCompat
+  get isDifferent() {
+    return !deepEqual(this.a, this.b);
+  }
+}`,
+    },
+  ],
+});

--- a/test/eslint-rules/no-computed-macros.test.mjs
+++ b/test/eslint-rules/no-computed-macros.test.mjs
@@ -446,8 +446,7 @@ class C {
   @sort("categories", "sortDef") sorted;
 }`,
       errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
-      output: `import { compare } from "@ember/utils";
-import { get } from "@ember/object";
+      output: `import { arraySortedByProperties } from "discourse/lib/array-tools";
 import { tracked } from "@glimmer/tracking";
 import { dependentKeyCompat } from "@ember/object/compat";
 class C {
@@ -456,20 +455,7 @@ class C {
 
   @dependentKeyCompat
   get sorted() {
-    const arr = this.categories;
-    if (!Array.isArray(arr)) {
-      return [];
-    }
-    return [...arr].sort((a, b) => {
-      for (const s of this.sortDef ?? []) {
-        const [prop, dir = "asc"] = s.split(":");
-        const result = compare(get(a, prop), get(b, prop));
-        if (result !== 0) {
-          return dir === "desc" ? -result : result;
-        }
-      }
-      return 0;
-    });
+    return arraySortedByProperties(this.categories, this.sortDef);
   }
 }`,
     },

--- a/test/eslint-rules/no-computed-macros.test.mjs
+++ b/test/eslint-rules/no-computed-macros.test.mjs
@@ -1263,6 +1263,58 @@ class C {
 }`,
     },
 
+    // ---- decorated property treated as reactive (no @tracked added) ----
+    {
+      name: "decorated property (@service) is treated as reactive",
+      code: `import { not } from "@ember/object/computed";
+class C {
+  @service currentUser;
+  @not("currentUser") isAnonymous;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { dependentKeyCompat } from "@ember/object/compat";
+class C {
+  @service currentUser;
+
+  @dependentKeyCompat
+  get isAnonymous() {
+    return !this.currentUser;
+  }
+}`,
+    },
+
+    // ---- implicit injection exclusion: promote to @computed ----
+    {
+      name: "undeclared auto-injected dep promotes to @computed",
+      code: `import { not } from "@ember/object/computed";
+class C {
+  @not("currentUser") isAnonymous;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { computed } from "@ember/object";
+class C {
+  @computed("currentUser")
+  get isAnonymous() {
+    return !this.currentUser;
+  }
+}`,
+    },
+    {
+      name: "mix of auto-injected and normal deps promotes entire usage to @computed",
+      code: `import { and } from "@ember/object/computed";
+class C {
+  @and("currentUser", "isEnabled") canEdit;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { computed } from "@ember/object";
+class C {
+  @computed("currentUser", "isEnabled")
+  get canEdit() {
+    return this.currentUser && this.isEnabled;
+  }
+}`,
+    },
+
     // ---- classic component detection: force @computed ----
     {
       name: "classic component: forces @computed instead of @dependentKeyCompat",

--- a/test/eslint-rules/no-computed-macros.test.mjs
+++ b/test/eslint-rules/no-computed-macros.test.mjs
@@ -67,11 +67,14 @@ class C {
   @alias("model.title") title;
 }`,
       errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
-      output: `import { computed } from "@ember/object";
+      output: `import { computed, set } from "@ember/object";
 class C {
   @computed("model.title")
   get title() {
     return this.model?.title;
+  }
+  set title(value) {
+    set(this, "model.title", value);
   }
 }`,
     },
@@ -92,6 +95,9 @@ class C {
   @dependentKeyCompat
   get myName() {
     return this.name;
+  }
+  set myName(value) {
+    this.name = value;
   }
 }`,
     },
@@ -722,6 +728,9 @@ class C {
   get lang() {
     return this.headerLang;
   }
+  set lang(value) {
+    this.headerLang = value;
+  }
 }`,
     },
     {
@@ -827,6 +836,9 @@ class C {
   get isDisabled() {
     return this.disabled;
   }
+  set isDisabled(value) {
+    this.disabled = value;
+  }
 }`,
     },
 
@@ -912,7 +924,7 @@ class C {
         { messageId: "replaceMacro" },
       ],
       output: `import { tracked } from "@glimmer/tracking";
-import { computed } from "@ember/object";
+import { computed, set } from "@ember/object";
 import { dependentKeyCompat } from "@ember/object/compat";
 class C {
   @tracked isHidden;
@@ -921,6 +933,9 @@ class C {
   @computed("model.title")
   get title() {
     return this.model?.title;
+  }
+  set title(value) {
+    set(this, "model.title", value);
   }
   @dependentKeyCompat
   get isVisible() {
@@ -934,6 +949,9 @@ class C {
   get showFeaturedTopic() {
     return this.model?.featured;
   }
+  set showFeaturedTopic(value) {
+    set(this, "model.featured", value);
+  }
 }`,
     },
 
@@ -945,11 +963,14 @@ class C {
   @emberAlias("model.title") title;
 }`,
       errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
-      output: `import { computed } from "@ember/object";
+      output: `import { computed, set } from "@ember/object";
 class C {
   @computed("model.title")
   get title() {
     return this.model?.title;
+  }
+  set title(value) {
+    set(this, "model.title", value);
   }
 }`,
     },
@@ -1042,7 +1063,7 @@ class C {
         { messageId: "replaceMacro" },
         { messageId: "replaceMacro" },
       ],
-      output: `import { computed } from "@ember/object";
+      output: `import { computed, set } from "@ember/object";
 import { dependentKeyCompat } from "@ember/object/compat";
 class C {
   static find(id) {
@@ -1054,6 +1075,9 @@ class C {
   @computed("model.title")
   get title() {
     return this.model?.title;
+  }
+  set title(value) {
+    set(this, "model.title", value);
   }
   @dependentKeyCompat
   get isVisible() {
@@ -1102,6 +1126,221 @@ class C {
   @dependentKeyCompat
   get deletingAll() {
     return this.postAction === "delete_all";
+  }
+}`,
+    },
+
+    // ---- @computed propagation: dep is another macro with nested deps ----
+    {
+      name: "macro depending on @computed macro also uses @computed",
+      code: `import { alias, not } from "@ember/object/computed";
+class C {
+  @alias("model.title") title;
+  @not("title") noTitle;
+}`,
+      errors: [
+        { messageId: "replaceMacro" },
+        { messageId: "replaceMacro" },
+        { messageId: "replaceMacro" },
+        { messageId: "replaceMacro" },
+      ],
+      output: `import { computed, set } from "@ember/object";
+class C {
+  @computed("model.title")
+  get title() {
+    return this.model?.title;
+  }
+  set title(value) {
+    set(this, "model.title", value);
+  }
+  @computed("title")
+  get noTitle() {
+    return !this.title;
+  }
+}`,
+    },
+    {
+      name: "transitive @computed propagation through macro chain",
+      code: `import { alias, not, bool } from "@ember/object/computed";
+class C {
+  @alias("model.title") title;
+  @not("title") noTitle;
+  @bool("noTitle") hasNoTitle;
+}`,
+      errors: [
+        { messageId: "replaceMacro" },
+        { messageId: "replaceMacro" },
+        { messageId: "replaceMacro" },
+        { messageId: "replaceMacro" },
+        { messageId: "replaceMacro" },
+        { messageId: "replaceMacro" },
+      ],
+      output: `import { computed, set } from "@ember/object";
+class C {
+  @computed("model.title")
+  get title() {
+    return this.model?.title;
+  }
+  set title(value) {
+    set(this, "model.title", value);
+  }
+  @computed("title")
+  get noTitle() {
+    return !this.title;
+  }
+  @computed("noTitle")
+  get hasNoTitle() {
+    return !!this.noTitle;
+  }
+}`,
+    },
+    {
+      name: "mixed @computed propagation and @dependentKeyCompat",
+      code: `import { alias, not, equal } from "@ember/object/computed";
+class C {
+  @alias("model.title") title;
+  @not("title") noTitle;
+  @equal("status", "active") isActive;
+}`,
+      errors: [
+        { messageId: "replaceMacro" },
+        { messageId: "replaceMacro" },
+        { messageId: "replaceMacro" },
+        { messageId: "replaceMacro" },
+        { messageId: "replaceMacro" },
+        { messageId: "replaceMacro" },
+      ],
+      output: `import { tracked } from "@glimmer/tracking";
+import { computed, set } from "@ember/object";
+import { dependentKeyCompat } from "@ember/object/compat";
+class C {
+  @tracked status;
+
+  @computed("model.title")
+  get title() {
+    return this.model?.title;
+  }
+  set title(value) {
+    set(this, "model.title", value);
+  }
+  @computed("title")
+  get noTitle() {
+    return !this.title;
+  }
+  @dependentKeyCompat
+  get isActive() {
+    return this.status === "active";
+  }
+}`,
+    },
+
+    // ---- @computed propagation from existing @computed getter ----
+    {
+      name: "macro depending on existing @computed getter uses @computed",
+      code: `import { computed } from "@ember/object";
+import { alias } from "@ember/object/computed";
+class C {
+  @computed("categories.[]", "shortcuts")
+  get categoriesWithShortcuts() {
+    return this.shortcuts.concat(this.categories);
+  }
+  @alias("categoriesWithShortcuts") content;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { computed, set } from "@ember/object";
+class C {
+  @computed("categoriesWithShortcuts")
+  get content() {
+    return this.categoriesWithShortcuts;
+  }
+  set content(value) {
+    set(this, "categoriesWithShortcuts", value);
+  }
+  @computed("categories.[]", "shortcuts")
+  get categoriesWithShortcuts() {
+    return this.shortcuts.concat(this.categories);
+  }
+}`,
+    },
+
+    // ---- classic component detection: force @computed ----
+    {
+      name: "classic component: forces @computed instead of @dependentKeyCompat",
+      code: `import Component from "@ember/component";
+import { alias } from "@ember/object/computed";
+class C extends Component {
+  @alias("name") myName;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import Component from "@ember/component";
+import { computed, set } from "@ember/object";
+class C extends Component {
+  @computed("name")
+  get myName() {
+    return this.name;
+  }
+  set myName(value) {
+    set(this, "name", value);
+  }
+}`,
+    },
+    {
+      name: "classic component detected via @classNames decorator",
+      code: `import { classNames } from "@ember-decorators/component";
+import { not } from "@ember/object/computed";
+@classNames("my-component")
+class C extends SomeBase {
+  @not("isHidden") isVisible;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { classNames } from "@ember-decorators/component";
+import { computed } from "@ember/object";
+@classNames("my-component")
+class C extends SomeBase {
+  @computed("isHidden")
+  get isVisible() {
+    return !this.isHidden;
+  }
+}`,
+    },
+    {
+      name: "classic component detected via superclass name ending in Component",
+      code: `import { alias } from "@ember/object/computed";
+class C extends ComboBoxComponent {
+  @alias("name") myName;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { computed, set } from "@ember/object";
+class C extends ComboBoxComponent {
+  @computed("name")
+  get myName() {
+    return this.name;
+  }
+  set myName(value) {
+    set(this, "name", value);
+  }
+}`,
+    },
+    {
+      name: "glimmer component is not treated as classic",
+      code: `import GlimmerComponent from "@glimmer/component";
+import { alias } from "@ember/object/computed";
+class C extends GlimmerComponent {
+  @alias("name") myName;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import GlimmerComponent from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { dependentKeyCompat } from "@ember/object/compat";
+class C extends GlimmerComponent {
+  @tracked name;
+
+  @dependentKeyCompat
+  get myName() {
+    return this.name;
+  }
+  set myName(value) {
+    this.name = value;
   }
 }`,
     },

--- a/test/eslint-rules/no-computed-macros.test.mjs
+++ b/test/eslint-rules/no-computed-macros.test.mjs
@@ -447,9 +447,13 @@ class C {
 }`,
       errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
       output: `import { compare } from "@ember/utils";
-import { computed } from "@ember/object";
+import { tracked } from "@glimmer/tracking";
+import { dependentKeyCompat } from "@ember/object/compat";
 class C {
-  @computed("categories.[]", "sortDef.[]")
+  @tracked categories;
+  @tracked sortDef;
+
+  @dependentKeyCompat
   get sorted() {
     const arr = this.categories;
     if (!Array.isArray(arr)) {
@@ -499,9 +503,12 @@ class C {
 }`,
       errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
       output: `import { uniqueItemsFromArray } from "discourse/lib/array-tools";
-import { computed } from "@ember/object";
+import { tracked } from "@glimmer/tracking";
+import { dependentKeyCompat } from "@ember/object/compat";
 class C {
-  @computed("items.[]")
+  @tracked items;
+
+  @dependentKeyCompat
   get uniqueItems() {
     return uniqueItemsFromArray(this.items ?? []);
   }
@@ -517,9 +524,13 @@ class C {
 }`,
       errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
       output: `import { uniqueItemsFromArray } from "discourse/lib/array-tools";
-import { computed } from "@ember/object";
+import { tracked } from "@glimmer/tracking";
+import { dependentKeyCompat } from "@ember/object/compat";
 class C {
-  @computed("a.[]", "b.[]")
+  @tracked a;
+  @tracked b;
+
+  @dependentKeyCompat
   get combined() {
     return uniqueItemsFromArray([...(this.a ?? []), ...(this.b ?? [])]);
   }
@@ -534,9 +545,13 @@ class C {
   @intersect("a", "b") common;
 }`,
       errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
-      output: `import { computed } from "@ember/object";
+      output: `import { tracked } from "@glimmer/tracking";
+import { dependentKeyCompat } from "@ember/object/compat";
 class C {
-  @computed("a.[]", "b.[]")
+  @tracked a;
+  @tracked b;
+
+  @dependentKeyCompat
   get common() {
     return this.b?.filter?.((item) => this.a?.includes?.(item)) ?? [];
   }
@@ -551,9 +566,13 @@ class C {
   @setDiff("a", "b") diff;
 }`,
       errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
-      output: `import { computed } from "@ember/object";
+      output: `import { tracked } from "@glimmer/tracking";
+import { dependentKeyCompat } from "@ember/object/compat";
 class C {
-  @computed("a.[]", "b.[]")
+  @tracked a;
+  @tracked b;
+
+  @dependentKeyCompat
   get diff() {
     return this.a?.filter?.((item) => !this.b?.includes?.(item)) ?? [];
   }
@@ -568,9 +587,12 @@ class C {
   @sum("values") total;
 }`,
       errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
-      output: `import { computed } from "@ember/object";
+      output: `import { tracked } from "@glimmer/tracking";
+import { dependentKeyCompat } from "@ember/object/compat";
 class C {
-  @computed("values.[]")
+  @tracked values;
+
+  @dependentKeyCompat
   get total() {
     return this.values?.reduce?.((s, v) => s + v, 0) ?? 0;
   }

--- a/test/eslint-rules/no-computed-macros.test.mjs
+++ b/test/eslint-rules/no-computed-macros.test.mjs
@@ -1068,6 +1068,26 @@ class C {
 }`,
     },
 
+    // ---- discourse/lib/decorators alias source ----
+    {
+      name: "macro imported from discourse/lib/decorators",
+      code: `import { not } from "discourse/lib/decorators";
+class C {
+  @not("loading") loaded;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { tracked } from "@glimmer/tracking";
+import { dependentKeyCompat } from "@ember/object/compat";
+class C {
+  @tracked loading;
+
+  @dependentKeyCompat
+  get loaded() {
+    return !this.loading;
+  }
+}`,
+    },
+
     // ---- mixed local/nested deps → @computed wins ----
     {
       name: "mixed local and nested deps → uses @computed",

--- a/test/eslint-rules/no-computed-macros.test.mjs
+++ b/test/eslint-rules/no-computed-macros.test.mjs
@@ -119,6 +119,86 @@ class C {
 }`,
     },
 
+    // ---- oneWay (local) — diverge-from-source setter ----
+    {
+      name: "@oneWay with local dep → override setter + @dependentKeyCompat",
+      code: `import { oneWay } from "@ember/object/computed";
+class C {
+  @oneWay("name") myName;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { tracked } from "@glimmer/tracking";
+import { dependentKeyCompat } from "@ember/object/compat";
+class C {
+  @tracked name;
+
+  @tracked _myNameOverride;
+
+  @dependentKeyCompat
+  get myName() {
+    if (this._myNameOverride !== undefined) {
+      return this._myNameOverride;
+    }
+    return this.name;
+  }
+  set myName(value) {
+    this._myNameOverride = value;
+  }
+}`,
+    },
+
+    // ---- oneWay (nested) — diverge-from-source setter ----
+    {
+      name: "@oneWay with nested dep → override setter + @computed",
+      code: `import { oneWay } from "@ember/object/computed";
+class C {
+  @oneWay("model.name") myName;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { tracked } from "@glimmer/tracking";
+import { computed } from "@ember/object";
+class C {
+  @tracked _myNameOverride;
+
+  @computed("model.name")
+  get myName() {
+    if (this._myNameOverride !== undefined) {
+      return this._myNameOverride;
+    }
+    return this.model?.name;
+  }
+  set myName(value) {
+    this._myNameOverride = value;
+  }
+}`,
+    },
+
+    // ---- reads (alias for oneWay) ----
+    {
+      name: "@reads with nested dep (alias for oneWay)",
+      code: `import { reads } from "@ember/object/computed";
+class C {
+  @reads("model.title") title;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { tracked } from "@glimmer/tracking";
+import { computed } from "@ember/object";
+class C {
+  @tracked _titleOverride;
+
+  @computed("model.title")
+  get title() {
+    if (this._titleOverride !== undefined) {
+      return this._titleOverride;
+    }
+    return this.model?.title;
+  }
+  set title(value) {
+    this._titleOverride = value;
+  }
+}`,
+    },
+
     // ---- not (local) ----
     {
       name: "@not with local dep",
@@ -319,7 +399,7 @@ class C {
 class C {
   @computed("themes.@each.name")
   get themeNames() {
-    return this.themes?.map((item) => item.name) ?? [];
+    return this.themes?.map?.((item) => item.name) ?? [];
   }
 }`,
     },
@@ -336,7 +416,7 @@ class C {
 class C {
   @computed("groups.@each.has_messages")
   get groupsWithMessages() {
-    return this.groups?.filter((item) => item.has_messages) ?? [];
+    return this.groups?.filter?.((item) => item.has_messages) ?? [];
   }
 }`,
     },
@@ -353,7 +433,7 @@ class C {
 class C {
   @computed("model.@each.is_favorite")
   get favoriteBadges() {
-    return this.model?.filter((item) => item.is_favorite === true) ?? [];
+    return this.model?.filter?.((item) => item.is_favorite === true) ?? [];
   }
 }`,
     },
@@ -371,7 +451,11 @@ import { computed } from "@ember/object";
 class C {
   @computed("categories.[]", "sortDef.[]")
   get sorted() {
-    return [...(this.categories ?? [])].sort((a, b) => {
+    const arr = this.categories;
+    if (!Array.isArray(arr)) {
+      return [];
+    }
+    return [...arr].sort((a, b) => {
       for (const s of this.sortDef ?? []) {
         const [prop, dir = "asc"] = s.split(":");
         const result = compare(a[prop], b[prop]);
@@ -454,7 +538,7 @@ class C {
 class C {
   @computed("a.[]", "b.[]")
   get common() {
-    return (this.b ?? []).filter((item) => (this.a ?? []).includes(item));
+    return this.b?.filter?.((item) => this.a?.includes?.(item)) ?? [];
   }
 }`,
     },
@@ -471,7 +555,7 @@ class C {
 class C {
   @computed("a.[]", "b.[]")
   get diff() {
-    return (this.a ?? []).filter((item) => !(this.b ?? []).includes(item));
+    return this.a?.filter?.((item) => !this.b?.includes?.(item)) ?? [];
   }
 }`,
     },
@@ -488,7 +572,7 @@ class C {
 class C {
   @computed("values.[]")
   get total() {
-    return this.values?.reduce((s, v) => s + v, 0) ?? 0;
+    return this.values?.reduce?.((s, v) => s + v, 0) ?? 0;
   }
 }`,
     },

--- a/test/eslint-rules/no-computed-macros.test.mjs
+++ b/test/eslint-rules/no-computed-macros.test.mjs
@@ -447,6 +447,7 @@ class C {
 }`,
       errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
       output: `import { compare } from "@ember/utils";
+import { get } from "@ember/object";
 import { tracked } from "@glimmer/tracking";
 import { dependentKeyCompat } from "@ember/object/compat";
 class C {
@@ -462,7 +463,7 @@ class C {
     return [...arr].sort((a, b) => {
       for (const s of this.sortDef ?? []) {
         const [prop, dir = "asc"] = s.split(":");
-        const result = compare(a[prop], b[prop]);
+        const result = compare(get(a, prop), get(b, prop));
         if (result !== 0) {
           return dir === "desc" ? -result : result;
         }
@@ -1499,6 +1500,94 @@ class C extends GlimmerComponent {
   }
   set myName(value) {
     this.name = value;
+  }
+}`,
+    },
+
+    // ---- undeclared dep exclusion for unknown superclasses ----
+    {
+      name: "unknown superclass with undeclared dep: promotes to @computed",
+      code: `import { alias } from "@ember/object/computed";
+import User from "discourse/models/user";
+class AdminUser extends User {
+  @alias("staff") isStaff;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { computed, set } from "@ember/object";
+import User from "discourse/models/user";
+class AdminUser extends User {
+  @computed("staff")
+  get isStaff() {
+    return this.staff;
+  }
+  set isStaff(value) {
+    set(this, "staff", value);
+  }
+}`,
+    },
+    {
+      name: "unknown superclass with declared local dep: still uses @tracked",
+      code: `import { not } from "@ember/object/computed";
+import User from "discourse/models/user";
+class AdminUser extends User {
+  isHidden = false;
+  @not("isHidden") isVisible;
+}`,
+      errors: [
+        { messageId: "replaceMacro" },
+        { messageId: "addTracked" },
+        { messageId: "replaceMacro" },
+      ],
+      output: `import { tracked } from "@glimmer/tracking";
+import { dependentKeyCompat } from "@ember/object/compat";
+import User from "discourse/models/user";
+class AdminUser extends User {
+  @tracked isHidden = false;
+
+  @dependentKeyCompat
+  get isVisible() {
+    return !this.isHidden;
+  }
+}`,
+    },
+    {
+      name: "known framework superclass with undeclared dep: still uses @tracked",
+      code: `import Controller from "@ember/controller";
+import { alias } from "@ember/object/computed";
+class MyController extends Controller {
+  @alias("name") myName;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import Controller from "@ember/controller";
+import { tracked } from "@glimmer/tracking";
+import { dependentKeyCompat } from "@ember/object/compat";
+class MyController extends Controller {
+  @tracked name;
+
+  @dependentKeyCompat
+  get myName() {
+    return this.name;
+  }
+  set myName(value) {
+    this.name = value;
+  }
+}`,
+    },
+    {
+      name: "non-Identifier superclass with undeclared dep: promotes to @computed",
+      code: `import { alias } from "@ember/object/computed";
+class C extends getBaseClass() {
+  @alias("name") myName;
+}`,
+      errors: [{ messageId: "replaceMacro" }, { messageId: "replaceMacro" }],
+      output: `import { computed, set } from "@ember/object";
+class C extends getBaseClass() {
+  @computed("name")
+  get myName() {
+    return this.name;
+  }
+  set myName(value) {
+    set(this, "name", value);
   }
 }`,
     },

--- a/test/eslint-rules/truth-helpers-imports.test.mjs
+++ b/test/eslint-rules/truth-helpers-imports.test.mjs
@@ -6,7 +6,7 @@ const ruleTester = new RuleTester();
 ruleTester.run("truth-helpers-imports", rule, {
   valid: [
     {
-      code: "import { and, eq } from 'truth-helpers';",
+      code: 'import { and, eq } from "truth-helpers";',
     },
   ],
   invalid: [
@@ -18,7 +18,7 @@ ruleTester.run("truth-helpers-imports", rule, {
             "It is recommended to use 'truth-helpers' import instead of 'truth-helpers/helpers/not'.",
         },
       ],
-      output: "import { not } from 'truth-helpers';",
+      output: 'import { not } from "truth-helpers";',
     },
     {
       code: "import notEq from 'truth-helpers/helpers/not-eq';",
@@ -28,7 +28,7 @@ ruleTester.run("truth-helpers-imports", rule, {
             "It is recommended to use 'truth-helpers' import instead of 'truth-helpers/helpers/not-eq'.",
         },
       ],
-      output: "import { notEq } from 'truth-helpers';",
+      output: 'import { notEq } from "truth-helpers";',
     },
     {
       code: "import or0 from 'truth-helpers/helpers/or';",
@@ -38,7 +38,7 @@ ruleTester.run("truth-helpers-imports", rule, {
             "It is recommended to use 'truth-helpers' import instead of 'truth-helpers/helpers/or'.",
         },
       ],
-      output: "import { or as or0 } from 'truth-helpers';",
+      output: 'import { or as or0 } from "truth-helpers";',
     },
   ],
 });


### PR DESCRIPTION
Adds an ESLint rule that converts computed property macro decorators from `@ember/object/computed` and `discourse/lib/computed` into native getters with `@computed` or `@dependentKeyCompat` + `@tracked`.

Supported macros:
- `@ember/object/computed`: `alias`, `reads`, `oneWay`, `and`, `or`, `not`, `notEmpty`, `empty`, `equal`, `gt`, `gte`, `lt`, `lte`, `match`, `collect`, `sort`, `filterBy`, `mapBy`
- `discourse/lib/computed`: `setting`, `fmt`, `propertyEqual`, `propertyNotEqual`, `i18n`, `url`

The rule handles:
- Macro-to-getter transformations with proper dependent keys
- Bidirectional macros (`alias`) with setter generation
- `@tracked` promotion for local dependencies
- `@computed` propagation when a converted getter depends on another converted macro
- Import cleanup and insertion (`@ember/object`, `@ember/utils`, `@glimmer/tracking`, etc.)
- Classic component detection for `@dependentKeyCompat` usage

Also refactors import statement building across existing rules (`no-discourse-computed`, `truth-helpers-imports`, `i18n-import-location`) into a shared `buildImportStatement` utility.