### PR TITLE
Remove template-no-multiple-empty-lines eslint rule

### DIFF
--- a/lint-configs/eslint.mjs
+++ b/lint-configs/eslint.mjs
@@ -268,7 +268,6 @@ export default [
 
       // From `ember-template-lint`'s old `stylistic` preset
       "ember/template-linebreak-style": "error",
-      "ember/template-no-multiple-empty-lines": "error",
       "ember/template-no-trailing-spaces": "error",
       "ember/template-no-unnecessary-concat": "error",
 

--- a/lint-configs/package.json
+++ b/lint-configs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@discourse/lint-configs",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Shareable lint configs for Discourse core, plugins, and themes",
   "author": "Discourse",
   "license": "MIT",


### PR DESCRIPTION
This rule has a bug upstream, which will be resolved by https://github.com/ember-cli/eslint-plugin-ember/pull/2781

But prettier actually handles this for us, so we can just drop the rule altogether.