### PR TITLE
DEV: Use new context.sourceCode / context.filename APIs

### DIFF
--- a/lint-configs/eslint-rules/i18n-import-location.mjs
+++ b/lint-configs/eslint-rules/i18n-import-location.mjs
@@ -49,13 +49,11 @@ export default {
                   ? localName
                   : `${sourceName} as ${localName}`;
 
-              const existingImport = context
-                .getSourceCode()
-                .ast.body.find(
-                  (n) =>
-                    n.type === "ImportDeclaration" &&
-                    n.source.value === "discourse-i18n"
-                );
+              const existingImport = context.sourceCode.ast.body.find(
+                (n) =>
+                  n.type === "ImportDeclaration" &&
+                  n.source.value === "discourse-i18n"
+              );
 
               if (existingImport) {
                 return [

--- a/lint-configs/eslint-rules/i18n-t.mjs
+++ b/lint-configs/eslint-rules/i18n-t.mjs
@@ -11,7 +11,7 @@ export default {
   },
 
   create(context) {
-    const sourceCode = context.sourceCode ?? context.getSourceCode();
+    const sourceCode = context.sourceCode;
     let alreadyFixedImport = false;
 
     return {

--- a/lint-configs/eslint-rules/keep-array-sorted.mjs
+++ b/lint-configs/eslint-rules/keep-array-sorted.mjs
@@ -9,7 +9,7 @@ export default {
   },
 
   create(context) {
-    const sourceCode = context.getSourceCode();
+    const sourceCode = context.sourceCode;
 
     return {
       ArrayExpression(node) {

--- a/lint-configs/eslint-rules/no-computed-macros.mjs
+++ b/lint-configs/eslint-rules/no-computed-macros.mjs
@@ -34,7 +34,7 @@ export default {
   },
 
   create(context) {
-    const sourceCode = context.getSourceCode();
+    const sourceCode = context.sourceCode;
     let analysis = null;
     let importsMap = null;
     let importFixGenerated = false;

--- a/lint-configs/eslint-rules/no-curly-components.mjs
+++ b/lint-configs/eslint-rules/no-curly-components.mjs
@@ -46,7 +46,7 @@ function lintCurlyComponent(node, context) {
   if (importedModuleName.startsWith(".")) {
     const cwd = context.cwd;
     const sourceDirectoryFromCwd = path.dirname(
-      path.relative(cwd, context.getFilename())
+      path.relative(cwd, context.filename)
     );
 
     resolvedModuleName = path.join(sourceDirectoryFromCwd, importedModuleName);

--- a/lint-configs/eslint-rules/no-discourse-computed.mjs
+++ b/lint-configs/eslint-rules/no-discourse-computed.mjs
@@ -183,7 +183,7 @@ export default {
   },
 
   create(context) {
-    const sourceCode = context.getSourceCode();
+    const sourceCode = context.sourceCode;
     let hasComputedImport = false;
     let emberObjectImportNode = null;
     let discourseComputedInfo = null; // Cache info about discourseComputed decorators

--- a/lint-configs/eslint-rules/no-route-template.mjs
+++ b/lint-configs/eslint-rules/no-route-template.mjs
@@ -24,7 +24,7 @@ export default {
             node,
             messageId: "removeRouteTemplate",
             fix(fixer) {
-              const sourceCode = context.getSourceCode();
+              const sourceCode = context.sourceCode;
               const arg = node.declaration.arguments[0];
               // Find import of RouteTemplate
               const importDecl = sourceCode.ast.body.find(

--- a/lint-configs/eslint-rules/test-filename-suffix.mjs
+++ b/lint-configs/eslint-rules/test-filename-suffix.mjs
@@ -20,7 +20,7 @@ export default {
   create(context) {
     return {
       Program(node) {
-        const filename = context.getFilename();
+        const filename = context.filename;
 
         if (!isTestFile(filename)) {
           return;


### PR DESCRIPTION
context.getSourceCode() and context.getFilename() were deprecated some time ago in favour of the property accessors. Replace remaining call sites — the new APIs already work on ESLint 9, and the deprecated ones are removed in ESLint 10.