### PR TITLE
Fix peerdependency definitions

### DIFF
--- a/lint-configs/package.json
+++ b/lint-configs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@discourse/lint-configs",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Shareable lint configs for Discourse core, plugins, and themes",
   "author": "Discourse",
   "license": "MIT",
@@ -33,20 +33,22 @@
     "@babel/eslint-parser": "^8.0.1",
     "@babel/plugin-proposal-decorators": "^8.0.2",
     "@eslint/js": "^10.0.1",
-    "eslint": "^10.6.0",
     "eslint-plugin-decorator-position": "^6.1.1",
     "eslint-plugin-ember": "^13.4.0",
     "eslint-plugin-qunit": "^8.2.6",
     "eslint-plugin-simple-import-sort": "^13.0.0",
     "eslint-plugin-sort-class-members": "^1.22.1",
     "globals": "^17.7.0",
-    "prettier": "^3.8.1",
     "prettier-plugin-ember-template-tag": "^2.1.3",
-    "stylelint": "^17.5.0",
     "stylelint-config-standard": "^40.0.0",
     "stylelint-config-standard-scss": "^17.0.0",
     "stylelint-scss": "^7.0.0",
     "typescript": "^5.9.3"
+  },
+  "devDependencies": {
+    "eslint": "10.6.0",
+    "prettier": "3.8.1",
+    "stylelint": "17.5.0"
   },
   "peerDependencies": {
     "eslint": "10.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,9 +22,6 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.6.0)
-      eslint:
-        specifier: ^10.6.0
-        version: 10.6.0
       eslint-plugin-decorator-position:
         specifier: ^6.1.1
         version: 6.1.1(@babel/eslint-parser@8.0.1(@babel/core@8.0.1)(eslint@10.6.0))(eslint@10.6.0)
@@ -43,15 +40,9 @@ importers:
       globals:
         specifier: ^17.7.0
         version: 17.7.0
-      prettier:
-        specifier: ^3.8.1
-        version: 3.8.1
       prettier-plugin-ember-template-tag:
         specifier: ^2.1.3
         version: 2.1.3(prettier@3.8.1)
-      stylelint:
-        specifier: ^17.5.0
-        version: 17.5.0(typescript@5.9.3)
       stylelint-config-standard:
         specifier: ^40.0.0
         version: 40.0.0(stylelint@17.5.0(typescript@5.9.3))
@@ -64,6 +55,16 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+    devDependencies:
+      eslint:
+        specifier: 10.6.0
+        version: 10.6.0
+      prettier:
+        specifier: 3.8.1
+        version: 3.8.1
+      stylelint:
+        specifier: 17.5.0
+        version: 17.5.0(typescript@5.9.3)
 
   test:
     devDependencies:
@@ -76,6 +77,9 @@ importers:
       prettier:
         specifier: 3.8.1
         version: 3.8.1
+      stylelint:
+        specifier: 17.5.0
+        version: 17.5.0(typescript@5.9.3)
 
   test/cjs:
     devDependencies:

--- a/test/package.json
+++ b/test/package.json
@@ -8,6 +8,7 @@
   "devDependencies": {
     "@discourse/lint-configs": "workspace:*",
     "eslint": "10.6.0",
-    "prettier": "3.8.1"
+    "prettier": "3.8.1",
+    "stylelint": "17.5.0"
   }
 }


### PR DESCRIPTION
Having eslint, prettier and stylelint in both 'dependencies' and 'peerDependencies' meant that pnpm didn't enforce the peerdep on consumers. The solution is to move them to devDependencies (for the CI in this repo), and otherwise rely entirely on the peerdeps.